### PR TITLE
Adjust normal-mode question distribution

### DIFF
--- a/app/static/index.html
+++ b/app/static/index.html
@@ -274,8 +274,8 @@
       const perfRaw = JSON.parse(localStorage.getItem(`quiz:${state.user}:perf`) || '{}');
 
       // 2バケット：
-      // A: 未回答 or 連続正解数がしきい値未満
-      // B: 連続正解数がしきい値以上
+      // B: 直近で連続正解がしきい値以上のもの（連続数が少ない順）
+      // A: 上記以外
       const bucketA = [];
       const bucketB = [];
 
@@ -301,23 +301,23 @@
         }
       }
 
-      // 目標比率：A 60% / B 40%（不足は相互補完）
-      const targetA = Math.round(n * 0.6);
+      // 目標比率：A 20% / B 80%（不足は相互補完）
+      const targetA = Math.round(n * 0.2);
       const targetB = n - targetA;
 
       const order = [];
-      const A = shuffle(bucketA); // 既存の shuffle() を利用
+      const A = shuffle(bucketA); // ランダム
       const B = bucketB
         .map(o=>({ ...o, rand: Math.random() }))
         .sort((a,b)=> (a.streak - b.streak) || (a.rand - b.rand))
         .map(o=>o.idx);
 
-      // まずAから
-      while (order.length < targetA && A.length) order.push(A.shift());
-      // 次にBから
-      while (order.length < targetA + targetB && B.length) order.push(B.shift());
-      // どちらか不足なら残りで補完
-      const rest = [...A, ...B];
+      // まずBから
+      while (order.length < targetB && B.length) order.push(B.shift());
+      // 次にAから
+      while (order.length < targetB + targetA && A.length) order.push(A.shift());
+      // どちらか不足なら残りで補完（B優先）
+      const rest = [...B, ...A];
       while (order.length < n && rest.length) order.push(rest.shift());
 
       return order;


### PR DESCRIPTION
## Summary
- Update normal-mode bucket logic so bucket B contains questions with consecutive correct streak ≥2, bucket A all others.
- Shift question selection ratio to 20% from bucket A and 80% from bucket B, prioritizing lower streak counts first.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b54f478e9c8333aec355c8a6ae700f