### PR TITLE
Revise quiz order to prioritize weak items

### DIFF
--- a/app/static/index.html
+++ b/app/static/index.html
@@ -268,7 +268,7 @@
       const deckArr = deck();
       const n = Math.min(state.totalPerSet, deckArr.length);
 
-      const STREAK_THRESHOLD = 2;       // 連続正解回数のしきい値
+      const STREAK_THRESHOLD = 1;       // 連続正解回数のしきい値
 
       // 学習履歴（直近30日を noteAttempt が保存）
       const perfRaw = JSON.parse(localStorage.getItem(`quiz:${state.user}:perf`) || '{}');


### PR DESCRIPTION
## Summary
- Lower streak threshold to 1 so any single correct answer counts toward selection

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b593e977cc8333a710776381e6178a