### PR TITLE
feat: show server recent stats and default to 5 questions

### DIFF
--- a/app/static/admin.html
+++ b/app/static/admin.html
@@ -51,6 +51,10 @@
           <span class="muted">単元</span>
           <select id="unit"><option value="">（すべて）</option></select>
         </label>
+        <label class="row" style="gap:6px">
+          <span class="muted">モード</span>
+          <select id="mode"><option value="normal">通常</option><option value="review">復習</option></select>
+        </label>
         <input id="search" placeholder="問題検索（日本語/英語/ID）" style="min-width:220px" />
         <span class="pill right" id="last-updated">更新: --</span>
       </div>
@@ -81,6 +85,13 @@
         <div style="max-height:340px; overflow:auto">
           <table id="tbl-recent"><thead><tr><th>日時</th><th>ID</th><th>結果</th><th>あなたの解答</th><th>正解</th><th>単元</th><th>ユーザ</th></tr></thead><tbody></tbody></table>
         </div>
+      </div>
+    </section>
+
+    <section class="card">
+      <h3 style="margin:0 0 8px">単語別正誤</h3>
+      <div style="max-height:340px; overflow:auto">
+        <table id="tbl-words"><thead><tr><th>ID</th><th>日本語</th><th>英語</th><th class="center">正答</th><th class="center">誤答</th><th class="center">正答率</th></tr></thead><tbody></tbody></table>
       </div>
     </section>
   </main>
@@ -162,6 +173,20 @@
         if(!ok){ tr.style.background='rgba(239,68,68,.08)'; }
         recent.appendChild(tr);
       });
+
+      // 単語別正誤
+      const qstat=$('#tbl-words tbody'); qstat.innerHTML='';
+      data.questionStats.forEach(q=>{
+        const acc = q.answered? Math.round(q.correct/q.answered*100):0;
+        const tr=document.createElement('tr');
+        tr.innerHTML = `<td>${q.id||''}</td>
+                        <td>${q.jp||''}</td>
+                        <td>${q.en||''}</td>
+                        <td class="center ok">${fmt(q.correct)}</td>
+                        <td class="center ng">${fmt(q.wrong)}</td>
+                        <td class="center">${acc}%</td>`;
+        qstat.appendChild(tr);
+      });
       $('#last-updated').textContent = '更新: ' + new Date().toLocaleTimeString();
     }
 
@@ -169,7 +194,8 @@
       const user = $('#user').value || '__all__';
       const unit = $('#unit').value || '';
       const q = $('#search').value.trim();
-      const data = await getJSON('/api/admin/summary', {user, unit, q});
+      const mode = $('#mode').value || 'normal';
+      const data = await getJSON('/api/admin/summary', {user, unit, q, mode});
 
       // unit セレクタを埋める（保持）
       const unitSel=$('#unit');
@@ -183,7 +209,8 @@
     async function main(){
       await loadUsers();
       await refresh();
-      $('#user').onchange=refresh; $('#unit').onchange=refresh; $('#search').oninput=()=>{ clearTimeout(window.__t); window.__t=setTimeout(refresh, 400); };
+      $('#user').onchange=refresh; $('#unit').onchange=refresh; $('#mode').onchange=refresh;
+      $('#search').oninput=()=>{ clearTimeout(window.__t); window.__t=setTimeout(refresh, 400); };
     }
 
     main().catch(e=>{ alert('読み込みに失敗しました: '+e.message); console.error(e); });

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -72,7 +72,7 @@
     <section class="card" id="setup">
       <div class="row">
         <label class="row" style="gap:6px"><span class="muted">学習者名</span><input id="learner" type="text" placeholder="taro" autocomplete="off" autocapitalize="off" list="user-suggestions" /></label><datalist id="user-suggestions"></datalist>
-        <label class="row" style="gap:6px"><span class="muted">1セットの出題数</span><input id="count" type="number" min="3" max="20" value="3" style="width:80px"/></label>
+        <label class="row" style="gap:6px"><span class="muted">1セットの出題数</span><input id="count" type="number" min="3" max="20" value="5" style="width:80px"/></label>
         <label class="row" style="gap:6px"><span class="muted">出題タイプ</span>
           <select id="qtype">
             <option value="reorder">並べ替え（文法）</option>
@@ -169,7 +169,8 @@
       totalPerSet:5, order:[], setIndex:0,
       qIndex:0, correct:0, wrong:0,
       startedAt:null, seconds:0, timerId:null,
-      answered:[],   // サーバ送信用（最小）
+      answered:[],   // サーバ送信用（通常モード）
+      reviewed:[],   // サーバ送信用（復習モード）
       graded:false,  // 一問一採点
       mode:'normal',
       reviewStrategy:'all', // 'all' | 'recent'
@@ -204,7 +205,7 @@
       if(!customDeck || !customDeck.length){ alert('このセットの間違いはありません。'); return; }
 
       // セット初期化
-      state.qIndex=0; state.correct=0; state.wrong=0; state.answered=[]; state.graded=false;
+      state.qIndex=0; state.correct=0; state.wrong=0; state.answered=[]; state.reviewed=[]; state.graded=false;
       $('#stat-correct').textContent='0'; $('#stat-wrong').textContent='0';
 
       // レビュー用デッキに流し込む（既存ロジック流用）
@@ -268,7 +269,7 @@
       const deckArr = deck();
       const n = Math.min(state.totalPerSet, deckArr.length);
 
-      const STREAK_THRESHOLD = 2;       // 連続正解回数のしきい値
+      const STREAK_THRESHOLD = 1;       // 連続正解回数のしきい値
 
       // 学習履歴（直近30日を noteAttempt が保存）
       const perfRaw = JSON.parse(localStorage.getItem(`quiz:${state.user}:perf`) || '{}');
@@ -365,14 +366,15 @@
       p[k]=rec; savePerf(p);
     }
     function updateRecentStat(q){
-      const p = loadPerf();
-      const k = qKeyOf(q);
-      const rec = p[k];
-      const cutoff = Date.now() - 30*24*3600*1000;
-      const arr = (rec && Array.isArray(rec.attempts)) ? rec.attempts.filter(a=> new Date(a.at).getTime() >= cutoff) : [];
-      const ok = arr.filter(a=>a.correct).length;
-      const txt = arr.length? `30日正解: ${ok}/${arr.length}` : '30日正解: --';
-      $('#stat-recent').textContent = txt;
+      const el = $('#stat-recent');
+      if(!state.user || !q.id){ el.textContent='30日正解: --'; return; }
+      fetch(`/api/recent?user=${encodeURIComponent(state.user)}&id=${encodeURIComponent(q.id)}`, {cache:'no-store'})
+        .then(res=>res.ok?res.json():null)
+        .then(data=>{
+          const ans=data?data.answered:0; const ok=data?data.correct:0;
+          el.textContent = ans? `30日正解: ${ok}/${ans}` : '30日正解: --';
+        })
+        .catch(()=>{ el.textContent='30日正解: --'; });
     }
     function weakCandidates(windowDays){
       const p = loadPerf();
@@ -405,7 +407,7 @@
       try{ await ensureQuestions(); }catch(e){ alert(e.message||e); return; }
       const d=deck();
       if(!d.length){ alert('この出題タイプの問題がありません。/data/questions.json をご確認ください。'); show('setup'); return; }
-      state.qIndex=0; state.correct=0; state.wrong=0; state.answered=[]; state.graded=false;
+      state.qIndex=0; state.correct=0; state.wrong=0; state.answered=[]; state.reviewed=[]; state.graded=false;
       $('#stat-correct').textContent='0'; $('#stat-wrong').textContent='0';
       if(state.mode==='review'){
         const ord = buildOrderFromWrong(state.reviewStrategy||'all');
@@ -511,7 +513,7 @@
         addWrongLocal({ type:state.qType, id:q.id||null, unit:q.unit||null, jp:q.jp, en:q.en, chunks:q.chunks, tip:q.tip||'', userAnswer: ans, at: record.at });
       }
 
-      state.answered.push(record);
+      (state.mode==='review'? state.reviewed : state.answered).push(record);
       noteAttempt(q, correct, record.at, state.mode);
       updateRecentStat(q);
       state.graded = true;
@@ -537,8 +539,9 @@
                     : (state.mode==='weak')  ? window.__WEAK_DECK__
                     : deck();
 
-      // answered の qIndex は「state.order 上の位置」なので、srcDeck と order から元問題を復元
-      const missedObjs = state.answered
+      // 解答記録（通常 or 復習）の qIndex は「state.order 上の位置」
+      const records = (state.mode==='review') ? state.reviewed : state.answered;
+      const missedObjs = records
         .filter(r=>!r.correct)
         .map(r=>{
           const idxInSrc = state.order[r.qIndex];
@@ -558,8 +561,10 @@
       }
 
       const wireAnswered = state.answered.map(({type,id,unit,userAnswer,correct,setIndex,qIndex,mode,at})=>({type,id,unit,userAnswer,correct,setIndex,qIndex,mode,at}));
+      const wireReviewed = state.reviewed.map(({type,id,unit,userAnswer,correct,setIndex,qIndex,mode,at})=>({type,id,unit,userAnswer,correct,setIndex,qIndex,mode,at}));
       const wireCorrect  = wireAnswered.filter(x=>x.correct);
       const wireMissed   = wireAnswered.filter(x=>!x.correct);
+      const wireReviewMissed = wireReviewed.filter(x=>!x.correct);
 
       const sessionWire = {
         user: state.user,
@@ -574,7 +579,9 @@
         endedAt: nowISO(),
         answered: wireAnswered,
         correctItems: wireCorrect,
-        missed: wireMissed
+        missed: wireMissed,
+        reviewed: wireReviewed,
+        reviewMissed: wireReviewMissed
       };
 
       // ローカル履歴はサマリのみ（軽量）

--- a/tests/test_recent.py
+++ b/tests/test_recent.py
@@ -1,0 +1,47 @@
+import json
+from datetime import datetime, timedelta, timezone
+
+
+def test_recent_endpoint_excludes_review(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    import importlib, sys
+    mod = importlib.import_module("app.app")
+    flask_app = mod.app
+    client = flask_app.test_client()
+    now = datetime.now(timezone.utc)
+    recs = [
+        {
+            "user": "alice",
+            "mode": "normal",
+            "endedAt": now.isoformat().replace("+00:00", "Z"),
+            "answered": [
+                {"id": "q1", "correct": True, "at": now.isoformat().replace("+00:00", "Z")},
+                {"id": "q1", "correct": False, "at": now.isoformat().replace("+00:00", "Z")},
+            ],
+        },
+        {
+            "user": "alice",
+            "mode": "review",
+            "endedAt": now.isoformat().replace("+00:00", "Z"),
+            "reviewed": [
+                {"id": "q1", "correct": True, "mode": "review", "at": now.isoformat().replace("+00:00", "Z")}
+            ],
+        },
+        {
+            "user": "alice",
+            "mode": "normal",
+            "endedAt": (now - timedelta(days=40)).isoformat().replace("+00:00", "Z"),
+            "answered": [
+                {"id": "q1", "correct": True, "at": (now - timedelta(days=40)).isoformat().replace("+00:00", "Z")}
+            ],
+        },
+    ]
+    path = tmp_path / "results.ndjson"
+    with open(path, "w", encoding="utf-8") as f:
+        for r in recs:
+            f.write(json.dumps(r) + "\n")
+    res = client.get("/api/recent", query_string={"user": "alice", "id": "q1"})
+    assert res.status_code == 200
+    data = res.get_json()
+    assert data == {"correct": 1, "answered": 2}
+    sys.modules.pop("app.app", None)

--- a/tests/test_recent.py
+++ b/tests/test_recent.py
@@ -4,7 +4,9 @@ from datetime import datetime, timedelta, timezone
 
 def test_recent_endpoint_excludes_review(tmp_path, monkeypatch):
     monkeypatch.setenv("DATA_DIR", str(tmp_path))
-    import importlib, sys
+    import importlib
+    import sys
+
     mod = importlib.import_module("app.app")
     flask_app = mod.app
     client = flask_app.test_client()
@@ -15,8 +17,16 @@ def test_recent_endpoint_excludes_review(tmp_path, monkeypatch):
             "mode": "normal",
             "endedAt": now.isoformat().replace("+00:00", "Z"),
             "answered": [
-                {"id": "q1", "correct": True, "at": now.isoformat().replace("+00:00", "Z")},
-                {"id": "q1", "correct": False, "at": now.isoformat().replace("+00:00", "Z")},
+                {
+                    "id": "q1",
+                    "correct": True,
+                    "at": now.isoformat().replace("+00:00", "Z"),
+                },
+                {
+                    "id": "q1",
+                    "correct": False,
+                    "at": now.isoformat().replace("+00:00", "Z"),
+                },
             ],
         },
         {
@@ -24,7 +34,12 @@ def test_recent_endpoint_excludes_review(tmp_path, monkeypatch):
             "mode": "review",
             "endedAt": now.isoformat().replace("+00:00", "Z"),
             "reviewed": [
-                {"id": "q1", "correct": True, "mode": "review", "at": now.isoformat().replace("+00:00", "Z")}
+                {
+                    "id": "q1",
+                    "correct": True,
+                    "mode": "review",
+                    "at": now.isoformat().replace("+00:00", "Z"),
+                }
             ],
         },
         {
@@ -32,7 +47,11 @@ def test_recent_endpoint_excludes_review(tmp_path, monkeypatch):
             "mode": "normal",
             "endedAt": (now - timedelta(days=40)).isoformat().replace("+00:00", "Z"),
             "answered": [
-                {"id": "q1", "correct": True, "at": (now - timedelta(days=40)).isoformat().replace("+00:00", "Z")}
+                {
+                    "id": "q1",
+                    "correct": True,
+                    "at": (now - timedelta(days=40)).isoformat().replace("+00:00", "Z"),
+                }
             ],
         },
     ]


### PR DESCRIPTION
## Summary
- default each set to 5 questions
- display 30-day correct counts from server data excluding review

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b593e977cc8333a710776381e6178a