### PR TITLE
Prioritize unattempted questions in selection

### DIFF
--- a/app/static/index.html
+++ b/app/static/index.html
@@ -274,8 +274,8 @@
       const perfRaw = JSON.parse(localStorage.getItem(`quiz:${state.user}:perf`) || '{}');
 
       // バケット：
-      // A: 最新の回答が誤りではないもの（未回答を含む）
-      // B: 上記以外（最新の回答が誤り）
+      // A: 最新の回答が正解である問題
+      // B: 最新の回答が誤り または 未回答の問題
       const bucketA = [];
       const bucketB = [];
 
@@ -286,7 +286,7 @@
 
         const attempts = (rec && Array.isArray(rec.attempts)) ? rec.attempts : [];
         if (attempts.length === 0) {
-          bucketA.push({ idx: i, streak: 0, rand: Math.random() });
+          bucketB.push(i);
           continue;
         }
 


### PR DESCRIPTION
## Summary
- Treat unanswered questions as Bucket B so they're prioritized early

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b72eb6d7008333a1d48c79637c00fd