### PR TITLE
Handle optional spaces before trailing punctuation

### DIFF
--- a/app/static/index.html
+++ b/app/static/index.html
@@ -188,7 +188,7 @@
     const shuffle = arr=>arr.map(v=>[Math.random(),v]).sort((a,b)=>a[0]-b[0]).map(x=>x[1]);
     const NBSP = String.fromCharCode(160);
     const normalizeSpaces = s=> s.replace(new RegExp(`[${NBSP}\\s]+`,'g'),' ').trim();
-    const normalizeEndPunc = s=> s.replace(/[.,!?]$/,'');
+    const normalizeEndPunc = s=> s.replace(/\s*[.,!?]$/,'');
     const normalizeWord = s=> normalizeSpaces(s).toLowerCase();
     const nowISO = ()=> new Date().toISOString();
 


### PR DESCRIPTION
## Summary
- Normalize string endings to strip trailing punctuation preceded by spaces
- Confirm currentAnswer joins tokens with spaces

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b8db89b2a48333a13a2367acb5eaf0