### PR TITLE
feat: split admin stats by question type

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -314,6 +314,7 @@ def admin_summary():
                 "unit": a.get("unit"),
                 "jp": a.get("jp"),
                 "en": a.get("en"),
+                "type": a.get("type"),
                 "answered": 0,
                 "correct": 0,
                 "wrong": 0,

--- a/app/static/admin.html
+++ b/app/static/admin.html
@@ -88,10 +88,18 @@
       </div>
     </section>
 
-    <section class="card">
-      <h3 style="margin:0 0 8px">単語別正誤</h3>
-      <div style="max-height:340px; overflow:auto">
-        <table id="tbl-words"><thead><tr><th>ID</th><th>日本語</th><th>英語</th><th class="center">正答</th><th class="center">誤答</th><th class="center">連続正解</th><th class="center">正答率</th></tr></thead><tbody></tbody></table>
+    <section class="grid cols-2">
+      <div class="card">
+        <h3 style="margin:0 0 8px">単語問題</h3>
+        <div style="max-height:340px; overflow:auto">
+          <table id="tbl-words-vocab"><thead><tr><th>ID</th><th>日本語</th><th>英語</th><th class="center">正答</th><th class="center">誤答</th><th class="center">連続正解</th><th class="center">正答率</th></tr></thead><tbody></tbody></table>
+        </div>
+      </div>
+      <div class="card">
+        <h3 style="margin:0 0 8px">並べ替え問題</h3>
+        <div style="max-height:340px; overflow:auto">
+          <table id="tbl-words-reorder"><thead><tr><th>ID</th><th>日本語</th><th>英語</th><th class="center">正答</th><th class="center">誤答</th><th class="center">連続正解</th><th class="center">正答率</th></tr></thead><tbody></tbody></table>
+        </div>
       </div>
     </section>
   </main>
@@ -174,8 +182,11 @@
         recent.appendChild(tr);
       });
 
-      // 単語別正誤
-      const qstat=$('#tbl-words tbody'); qstat.innerHTML='';
+      // 問題別正誤
+      const qVocab=$('#tbl-words-vocab tbody');
+      const qReorder=$('#tbl-words-reorder tbody');
+      qVocab.innerHTML='';
+      qReorder.innerHTML='';
       data.questionStats.forEach(q=>{
         const acc = q.answered? Math.round(q.correct/q.answered*100):0;
         const tr=document.createElement('tr');
@@ -186,7 +197,7 @@
                         <td class="center ng">${fmt(q.wrong)}</td>
                         <td class="center">${fmt(q.streak||0)}</td>
                         <td class="center">${acc}%</td>`;
-        qstat.appendChild(tr);
+        if(q.type==='vocab') qVocab.appendChild(tr); else qReorder.appendChild(tr);
       });
       $('#last-updated').textContent = '更新: ' + new Date().toLocaleTimeString();
     }


### PR DESCRIPTION
## Summary
- add question type information to admin summary
- display vocabulary and reorder stats in separate tables on admin page

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68bae7bbb0dc83338b7116ac07ba2ca9