### PR TITLE
Normalize capitalization for reorder answers

### DIFF
--- a/app/static/index.html
+++ b/app/static/index.html
@@ -468,7 +468,7 @@
         $('#ui-vocab').style.display='none';
         $('#prompt').innerHTML = q.jp ? `${q.jp}<br><span class="muted">ヒント: ${q.tip||''}</span>` : '<span class="muted">語順を並べ替えましょう</span>';
         const target=$('#target'); const bank=$('#bank'); target.innerHTML=''; bank.innerHTML='';
-        const chunks = shuffle(q.chunks);
+        const chunks = shuffle(q.chunks.map((c,i)=> i ? c : c.charAt(0).toLowerCase()+c.slice(1)));
         chunks.forEach((c,i)=>{
           const chip=document.createElement('button'); chip.className='chip'; chip.setAttribute('data-text',c); chip.textContent=`${i+1}. ${c}`;
           chip.onclick=()=>placeChip(chip); bank.appendChild(chip);
@@ -504,6 +504,7 @@
       if(state.qType==='reorder'){
         if($$('#target .chip').length !== q.chunks.length){ $('#explain').innerHTML='<span class="ng">まだ並べ終えていません。</span>'; return; }
         ans = normalizeEndPunc(normalizeSpaces(currentAnswer()));
+        ans = ans? ans.charAt(0).toUpperCase()+ans.slice(1) : ans;
         right = normalizeEndPunc(normalizeSpaces(q.en));
         correct = (ans===right);
       } else { // vocab
@@ -524,7 +525,7 @@
 
       if(correct){
         state.correct++; $('#stat-correct').textContent = state.correct;
-        $('#explain').innerHTML = `✅ 正解！ <span class="muted">${q.en}</span>`;
+        $('#explain').innerHTML = `✅ 正解！ <span class="muted">${ans}</span>`;
         removeFromWrongIfMatched({id:q.id, jp:q.jp, en:q.en});
       } else {
         state.wrong++; $('#stat-wrong').textContent = state.wrong;


### PR DESCRIPTION
## Summary
- Lowercase the first shuffled chunk when rendering reorder questions
- Capitalize assembled reorder answers before evaluation and logging

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68bbf4182cc483338d5eee366872a69c