### PR TITLE
Preserve provided chunk casing

### DIFF
--- a/app/static/index.html
+++ b/app/static/index.html
@@ -467,7 +467,7 @@
         $('#ui-vocab').style.display='none';
         $('#prompt').innerHTML = q.jp ? `${q.jp}<br><span class="muted">ヒント: ${q.tip||''}</span>` : '<span class="muted">語順を並べ替えましょう</span>';
         const target=$('#target'); const bank=$('#bank'); target.innerHTML=''; bank.innerHTML='';
-        const chunks = shuffle(q.chunks.map((c,i)=> i ? c : c.charAt(0).toLowerCase()+c.slice(1)));
+        const chunks = shuffle(q.chunks.slice());
         chunks.forEach((c,i)=>{
           const chip=document.createElement('button'); chip.className='chip'; chip.setAttribute('data-text',c); chip.textContent=`${i+1}. ${c}`;
           chip.onclick=()=>placeChip(chip); bank.appendChild(chip);


### PR DESCRIPTION
## Summary
- Stop lowercasing the first chunk in reorder questions so words display exactly as stored

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68bdfe8240ac8333a155ed7979f4aa07