### PR TITLE
Handle punctuation in reorder questions

### DIFF
--- a/app/static/index.html
+++ b/app/static/index.html
@@ -187,7 +187,7 @@
     const shuffle = arr=>arr.map(v=>[Math.random(),v]).sort((a,b)=>a[0]-b[0]).map(x=>x[1]);
     const NBSP = String.fromCharCode(160);
     const normalizeSpaces = s=> s.replace(new RegExp(`[${NBSP}\\s]+`,'g'),' ').trim();
-    const normalizeEndPunc = s=> s.replace(/\s*[.,!?]$/,'');
+    const normalizeEndPunc = (s, keep=false)=> keep ? s : s.replace(/\s*[.,!?]$/,'');
     const normalizeWord = s=> normalizeSpaces(s).toLowerCase();
     const nowISO = ()=> new Date().toISOString();
 
@@ -501,9 +501,10 @@
 
       let ans, right, correct;
       if(state.qType==='reorder'){
-        ans = normalizeEndPunc(normalizeSpaces(currentAnswer()));
+        const keepPunc = true; // 並び替えでは文末記号を保持する
+        ans = normalizeEndPunc(normalizeSpaces(currentAnswer()), keepPunc);
         ans = ans? ans.charAt(0).toUpperCase()+ans.slice(1) : ans;
-        right = normalizeEndPunc(normalizeSpaces(q.en));
+        right = normalizeEndPunc(normalizeSpaces(q.en), keepPunc);
         correct = (ans===right);
       } else { // vocab
         ans = normalizeWord(currentAnswer());

--- a/tests/test_normalize_end_punc.py
+++ b/tests/test_normalize_end_punc.py
@@ -1,0 +1,41 @@
+import json
+import subprocess
+from pathlib import Path
+
+def run_node(script: str) -> str:
+    res = subprocess.run(
+        ["node", "-e", script], capture_output=True, text=True, check=True
+    )
+    return res.stdout.strip()
+
+
+def test_reorder_punctuation_judgement():
+    index = Path("app/static/index.html").read_text(encoding="utf-8").splitlines()
+    lines = {}
+    for line in index:
+        s = line.strip()
+        if s.startswith("const NBSP"):  # NBSP constant
+            lines["NBSP"] = s
+        elif s.startswith("const normalizeSpaces"):
+            lines["normalizeSpaces"] = s
+        elif s.startswith("const normalizeEndPunc"):
+            lines["normalizeEndPunc"] = s
+    script = f"""
+{lines['NBSP']}
+{lines['normalizeSpaces']}
+{lines['normalizeEndPunc']}
+function grade(ans, right, keep) {{
+  ans = normalizeEndPunc(normalizeSpaces(ans), keep);
+  ans = ans? ans.charAt(0).toUpperCase()+ans.slice(1) : ans;
+  right = normalizeEndPunc(normalizeSpaces(right), keep);
+  return ans === right;
+}}
+console.log(JSON.stringify([
+  grade('Hello world', 'Hello world.', true),
+  grade('Hello world.', 'Hello world.', true),
+  grade('Hello world', 'Hello world.', false)
+]));
+"""
+    out = run_node(script)
+    result = json.loads(out)
+    assert result == [False, True, True]


### PR DESCRIPTION
## Summary
- Allow normalizeEndPunc to optionally retain trailing punctuation
- Preserve punctuation when grading reorder questions
- Test that punctuation differences affect reorder grading

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68bffa57437483338f35cc763cf2b0b3