### PR TITLE
fix punctuation spacing in normalization

### DIFF
--- a/app/static/index.html
+++ b/app/static/index.html
@@ -187,7 +187,7 @@
     const shuffle = arr=>arr.map(v=>[Math.random(),v]).sort((a,b)=>a[0]-b[0]).map(x=>x[1]);
     const NBSP = String.fromCharCode(160);
     const normalizeSpaces = s=> s.replace(new RegExp(`[${NBSP}\\s]+`,'g'),' ').trim();
-    const normalizeEndPunc = (s, keep=false)=> keep ? s : s.replace(/\s*[.,!?]$/,'');
+    const normalizeEndPunc = (s, keep=false)=> keep ? s.replace(/\s+([.,!?])/g, "$1") : s.replace(/\s*[.,!?]$/,'');
     const normalizeWord = s=> normalizeSpaces(s).toLowerCase();
     const nowISO = ()=> new Date().toISOString();
 

--- a/tests/test_normalize_end_punc.py
+++ b/tests/test_normalize_end_punc.py
@@ -34,9 +34,10 @@ function grade(ans, right, keep) {{
 console.log(JSON.stringify([
   grade('Hello world', 'Hello world.', true),
   grade('Hello world.', 'Hello world.', true),
+  grade('Hello world .', 'Hello world.', true),
   grade('Hello world', 'Hello world.', false)
 ]));
 """
     out = run_node(script)
     result = json.loads(out)
-    assert result == [False, True, True]
+    assert result == [False, True, True, True]


### PR DESCRIPTION
## Summary
- strip spaces before punctuation when keeping sentence-ending marks
- allow grades to accept answers with a space before punctuation

## Testing
- `pytest`
- `node - <<'NODE'` script verifying punctuation spacing


------
https://chatgpt.com/codex/tasks/task_b_68c0af9e10288333a0c49a4366d6dc93