### PR TITLE
Add wrong-choice support for reorder questions

### DIFF
--- a/app/static/data/questions.json
+++ b/app/static/data/questions.json
@@ -1,81 +1,753 @@
 {
-  "meta": { "version": 2, "lang": "ja-en", "note": "並べ替え(questions)＋単語(vocab) を同居" },
-
-"questions": [
-  { "id": "r001", "unit": "present-simple", "jp": "彼は放課後にサッカーをします。", "en": "He plays soccer after school.", "chunks": ["he","plays","soccer","after school",".","is"], "tip": "三単現: He plays（sを忘れずに）" },
-  { "id": "r002", "unit": "present-continuous-q", "jp": "あなたは今宿題をしていますか。", "en": "Are you doing your homework now?", "chunks": ["are","you","doing","your homework","now","?","has"], "tip": "進行形の疑問: Are you ～?" },
-  { "id": "r003", "unit": "past-simple", "jp": "私は昨日その博物館に行きました。", "en": "I went to the museum yesterday.", "chunks": ["I","went","to the museum","yesterday",".","am"], "tip": "go の過去形は went" },
-  { "id": "r004", "unit": "comparative", "jp": "この本はあの本よりおもしろい。", "en": "This book is more interesting than that one.", "chunks": ["this book","is","more interesting","than that one",".","do"], "tip": "比較級: more … than ～" },
-  { "id": "r005", "unit": "there-is", "jp": "机の下に猫が一匹います。", "en": "There is a cat under the desk.", "chunks": ["there is","a cat","under the desk",".","does"], "tip": "存在文: There is/are" },
-  { "id": "r006", "unit": "present-3sg", "jp": "彼女は毎朝朝ごはんを食べます。", "en": "She has breakfast every morning.", "chunks": ["she","has","breakfast","every morning",".","are"], "tip": "have → has（3単現）" },
-  { "id": "r007", "unit": "present-continuous", "jp": "私は英語を勉強しているところです。", "en": "I am studying English.", "chunks": ["I","am","studying","English",".","does"], "tip": "be + -ing で進行形" },
-  { "id": "r008", "unit": "past-simple-q", "jp": "あなたは昨日映画を見ましたか。", "en": "Did you watch a movie yesterday?", "chunks": ["did","you","watch","a movie","yesterday","?","is"], "tip": "過去の疑問: Did + 主語 + 動詞原形" },
-  { "id": "r009", "unit": "present-simple", "jp": "私は毎日朝ごはんを食べます。", "en": "I eat breakfast every day.", "chunks": ["I","eat","breakfast","every day",".","is"], "tip": "一般動詞の現在形: 主語 + 動詞原形" },
-  { "id": "r010", "unit": "present-simple-q", "jp": "あなたはサッカーが好きですか。", "en": "Do you like soccer?", "chunks": ["do","you","like","soccer","?","am"], "tip": "一般動詞の疑問文: Do + 主語 + 動詞原形" },
-  { "id": "r011", "unit": "be-verb", "jp": "彼女は生徒です。", "en": "She is a student.", "chunks": ["she","is","a student",".","do"], "tip": "be動詞の肯定文: 主語 + be動詞 + 補語" },
-  { "id": "r012", "unit": "be-verb-neg", "jp": "私は先生ではありません。", "en": "I am not a teacher.", "chunks": ["I","am","not","a teacher",".","does"], "tip": "be動詞の否定文: 主語 + be動詞 + not + 補語" },
-  { "id": "r013", "unit": "be-verb-q", "jp": "彼はアメリカ出身ですか。", "en": "Is he from America?", "chunks": ["is","he","from","America","?","do"], "tip": "be動詞の疑問文: Be動詞 + 主語 + 補語" },
-  { "id": "r014", "unit": "present-cont-q", "jp": "彼らはいまサッカーをしていますか。", "en": "Are they playing soccer now?", "chunks": ["are","they","playing","soccer","now","?","has"], "tip": "現在進行形の疑問文: Be動詞 + 主語 + 動詞ing" },
-  { "id": "r015", "unit": "present-cont-neg", "jp": "彼はテレビを見ていません。", "en": "He is not watching TV.", "chunks": ["he","is","not","watching","TV",".","do"], "tip": "現在進行形の否定文: 主語 + be動詞 + not + 動詞ing" },
-  { "id": "r016", "unit": "present-simple-q", "jp": "あなたのお父さんは日曜日にテニスをしますか。", "en": "Does your father play tennis on Sunday?", "chunks": ["does","your father","play","tennis","on Sunday","?","am"], "tip": "三単現の疑問文: Does + 主語 + 動詞原形" },
-  { "id": "r017", "unit": "present-simple-neg", "jp": "私は図書館で勉強しません。", "en": "I do not study in the library.", "chunks": ["I","do not","study","in the library",".","is"], "tip": "一般動詞の否定文: do not + 動詞原形" },
-  { "id": "r018", "unit": "be-verb-q", "jp": "これらの本はあなたのですか。", "en": "Are these books yours?", "chunks": ["are","these books","yours","?","does"], "tip": "be動詞の疑問文（複数）: Are + 複数主語" },
-  { "id": "r019", "unit": "present-cont-q", "jp": "あなたのお姉さんはいまピアノを弾いていますか。", "en": "Is your sister playing the piano now?", "chunks": ["is","your sister","playing","the piano","now","?","do"], "tip": "現在進行形の疑問文: Be動詞 + 主語 + 動詞ing" },
-  { "id": "r020", "unit": "there-are", "jp": "机の上に3本のえんぴつがあります。", "en": "There are three pencils on the desk.", "chunks": ["there are","three pencils","on the desk",".","does"], "tip": "存在文（複数）: There are + 複数名詞" }
-]
-,
-
+  "meta": {
+    "version": 2,
+    "lang": "ja-en",
+    "note": "並べ替え(questions)＋単語(vocab) を同居"
+  },
+  "questions": [
+    {
+      "id": "r001",
+      "unit": "present-simple",
+      "jp": "彼は放課後にサッカーをします。",
+      "en": "He plays soccer after school.",
+      "chunks": [
+        "he",
+        "plays",
+        "soccer",
+        "after school",
+        "."
+      ],
+      "tip": "三単現: He plays（sを忘れずに）",
+      "wrong": [
+        "is"
+      ]
+    },
+    {
+      "id": "r002",
+      "unit": "present-continuous-q",
+      "jp": "あなたは今宿題をしていますか。",
+      "en": "Are you doing your homework now?",
+      "chunks": [
+        "are",
+        "you",
+        "doing",
+        "your homework",
+        "now",
+        "?"
+      ],
+      "tip": "進行形の疑問: Are you ～?",
+      "wrong": [
+        "has"
+      ]
+    },
+    {
+      "id": "r003",
+      "unit": "past-simple",
+      "jp": "私は昨日その博物館に行きました。",
+      "en": "I went to the museum yesterday.",
+      "chunks": [
+        "I",
+        "went",
+        "to the museum",
+        "yesterday",
+        "."
+      ],
+      "tip": "go の過去形は went",
+      "wrong": [
+        "am"
+      ]
+    },
+    {
+      "id": "r004",
+      "unit": "comparative",
+      "jp": "この本はあの本よりおもしろい。",
+      "en": "This book is more interesting than that one.",
+      "chunks": [
+        "this book",
+        "is",
+        "more interesting",
+        "than that one",
+        "."
+      ],
+      "tip": "比較級: more … than ～",
+      "wrong": [
+        "do"
+      ]
+    },
+    {
+      "id": "r005",
+      "unit": "there-is",
+      "jp": "机の下に猫が一匹います。",
+      "en": "There is a cat under the desk.",
+      "chunks": [
+        "there is",
+        "a cat",
+        "under the desk",
+        "."
+      ],
+      "tip": "存在文: There is/are",
+      "wrong": [
+        "does"
+      ]
+    },
+    {
+      "id": "r006",
+      "unit": "present-3sg",
+      "jp": "彼女は毎朝朝ごはんを食べます。",
+      "en": "She has breakfast every morning.",
+      "chunks": [
+        "she",
+        "has",
+        "breakfast",
+        "every morning",
+        "."
+      ],
+      "tip": "have → has（3単現）",
+      "wrong": [
+        "are"
+      ]
+    },
+    {
+      "id": "r007",
+      "unit": "present-continuous",
+      "jp": "私は英語を勉強しているところです。",
+      "en": "I am studying English.",
+      "chunks": [
+        "I",
+        "am",
+        "studying",
+        "English",
+        "."
+      ],
+      "tip": "be + -ing で進行形",
+      "wrong": [
+        "does"
+      ]
+    },
+    {
+      "id": "r008",
+      "unit": "past-simple-q",
+      "jp": "あなたは昨日映画を見ましたか。",
+      "en": "Did you watch a movie yesterday?",
+      "chunks": [
+        "did",
+        "you",
+        "watch",
+        "a movie",
+        "yesterday",
+        "?"
+      ],
+      "tip": "過去の疑問: Did + 主語 + 動詞原形",
+      "wrong": [
+        "is"
+      ]
+    },
+    {
+      "id": "r009",
+      "unit": "present-simple",
+      "jp": "私は毎日朝ごはんを食べます。",
+      "en": "I eat breakfast every day.",
+      "chunks": [
+        "I",
+        "eat",
+        "breakfast",
+        "every day",
+        "."
+      ],
+      "tip": "一般動詞の現在形: 主語 + 動詞原形",
+      "wrong": [
+        "is"
+      ]
+    },
+    {
+      "id": "r010",
+      "unit": "present-simple-q",
+      "jp": "あなたはサッカーが好きですか。",
+      "en": "Do you like soccer?",
+      "chunks": [
+        "do",
+        "you",
+        "like",
+        "soccer",
+        "?"
+      ],
+      "tip": "一般動詞の疑問文: Do + 主語 + 動詞原形",
+      "wrong": [
+        "am"
+      ]
+    },
+    {
+      "id": "r011",
+      "unit": "be-verb",
+      "jp": "彼女は生徒です。",
+      "en": "She is a student.",
+      "chunks": [
+        "she",
+        "is",
+        "a student",
+        "."
+      ],
+      "tip": "be動詞の肯定文: 主語 + be動詞 + 補語",
+      "wrong": [
+        "do"
+      ]
+    },
+    {
+      "id": "r012",
+      "unit": "be-verb-neg",
+      "jp": "私は先生ではありません。",
+      "en": "I am not a teacher.",
+      "chunks": [
+        "I",
+        "am",
+        "not",
+        "a teacher",
+        "."
+      ],
+      "tip": "be動詞の否定文: 主語 + be動詞 + not + 補語",
+      "wrong": [
+        "does"
+      ]
+    },
+    {
+      "id": "r013",
+      "unit": "be-verb-q",
+      "jp": "彼はアメリカ出身ですか。",
+      "en": "Is he from America?",
+      "chunks": [
+        "is",
+        "he",
+        "from",
+        "America",
+        "?"
+      ],
+      "tip": "be動詞の疑問文: Be動詞 + 主語 + 補語",
+      "wrong": [
+        "do"
+      ]
+    },
+    {
+      "id": "r014",
+      "unit": "present-cont-q",
+      "jp": "彼らはいまサッカーをしていますか。",
+      "en": "Are they playing soccer now?",
+      "chunks": [
+        "are",
+        "they",
+        "playing",
+        "soccer",
+        "now",
+        "?"
+      ],
+      "tip": "現在進行形の疑問文: Be動詞 + 主語 + 動詞ing",
+      "wrong": [
+        "has"
+      ]
+    },
+    {
+      "id": "r015",
+      "unit": "present-cont-neg",
+      "jp": "彼はテレビを見ていません。",
+      "en": "He is not watching TV.",
+      "chunks": [
+        "he",
+        "is",
+        "not",
+        "watching",
+        "TV",
+        "."
+      ],
+      "tip": "現在進行形の否定文: 主語 + be動詞 + not + 動詞ing",
+      "wrong": [
+        "do"
+      ]
+    },
+    {
+      "id": "r016",
+      "unit": "present-simple-q",
+      "jp": "あなたのお父さんは日曜日にテニスをしますか。",
+      "en": "Does your father play tennis on Sunday?",
+      "chunks": [
+        "does",
+        "your father",
+        "play",
+        "tennis",
+        "on Sunday",
+        "?"
+      ],
+      "tip": "三単現の疑問文: Does + 主語 + 動詞原形",
+      "wrong": [
+        "am"
+      ]
+    },
+    {
+      "id": "r017",
+      "unit": "present-simple-neg",
+      "jp": "私は図書館で勉強しません。",
+      "en": "I do not study in the library.",
+      "chunks": [
+        "I",
+        "do not",
+        "study",
+        "in the library",
+        "."
+      ],
+      "tip": "一般動詞の否定文: do not + 動詞原形",
+      "wrong": [
+        "is"
+      ]
+    },
+    {
+      "id": "r018",
+      "unit": "be-verb-q",
+      "jp": "これらの本はあなたのですか。",
+      "en": "Are these books yours?",
+      "chunks": [
+        "are",
+        "these books",
+        "yours",
+        "?"
+      ],
+      "tip": "be動詞の疑問文（複数）: Are + 複数主語",
+      "wrong": [
+        "does"
+      ]
+    },
+    {
+      "id": "r019",
+      "unit": "present-cont-q",
+      "jp": "あなたのお姉さんはいまピアノを弾いていますか。",
+      "en": "Is your sister playing the piano now?",
+      "chunks": [
+        "is",
+        "your sister",
+        "playing",
+        "the piano",
+        "now",
+        "?"
+      ],
+      "tip": "現在進行形の疑問文: Be動詞 + 主語 + 動詞ing",
+      "wrong": [
+        "do"
+      ]
+    },
+    {
+      "id": "r020",
+      "unit": "there-are",
+      "jp": "机の上に3本のえんぴつがあります。",
+      "en": "There are three pencils on the desk.",
+      "chunks": [
+        "there are",
+        "three pencils",
+        "on the desk",
+        "."
+      ],
+      "tip": "存在文（複数）: There are + 複数名詞",
+      "wrong": [
+        "does"
+      ]
+    }
+  ],
   "vocab": [
-{ "id": "v001", "unit": "動詞-基本", "jp": "会う", "en": "meet", "pos": "verb", "tip":  "" },
-{ "id": "v002", "unit": "動詞-基本", "jp": "忘れる", "en": "forget", "pos": "verb", "tip":  "" },
-{ "id": "v003", "unit": "形容詞-基本", "jp": "怖い", "en": "scary", "pos": "adjective", "tip":  "" },
-{ "id": "v004", "unit": "形容詞-基本", "jp": "他の", "en": "other", "pos": "adjective", "tip":  "" },
-{ "id": "v005", "unit": "動詞-基本", "jp": "探す（探している最中）", "en": "look for", "pos": "verb", "tip":  "" },
-{ "id": "v006", "unit": "動詞-基本", "jp": "感じる", "en": "feel", "pos": "verb", "tip":  "" },
-{ "id": "v007", "unit": "動詞-基本", "jp": "尋ねる", "en": "ask", "pos": "verb", "tip":  "" },
-{ "id": "v008", "unit": "形容詞-基本", "jp": "わくわくする", "en": "excited", "pos": "adjective", "tip":  "" },
-{ "id": "v009", "unit": "形容詞-基本", "jp": "大切な", "en": "important", "pos": "adjective", "tip":  "" },
-{ "id": "v010", "unit": "前置詞-基本", "jp": "周りに", "en": "around", "pos": "preposition", "tip":  "" },
-{ "id": "v011", "unit": "形容詞-基本", "jp": "同じ", "en": "same", "pos": "adjective", "tip":  "" },
-{ "id": "v012", "unit": "副詞-基本", "jp": "決して～ない", "en": "never", "pos": "adverb", "tip":  "" },
-{ "id": "v013", "unit": "形容詞-基本", "jp": "もちろん", "en": "sure", "pos": "adjective", "tip":  "" },
-{ "id": "v014", "unit": "代名詞-基本", "jp": "両方", "en": "both", "pos": "pronoun", "tip":  "" },
-{ "id": "v015", "unit": "副詞-基本", "jp": "離れて", "en": "away", "pos": "adverb", "tip":  "" },
-{ "id": "v016", "unit": "動詞-基本", "jp": "出発する", "en": "leave", "pos": "verb", "tip":  "" },
-{ "id": "v017", "unit": "動詞-基本", "jp": "思い出す", "en": "remember", "pos": "verb", "tip":  "" },
-{ "id": "v018", "unit": "名詞-基本", "jp": "問題", "en": "problem", "pos": "noun", "tip":  "" },
-{ "id": "v019", "unit": "副詞-基本", "jp": "十分に", "en": "enough", "pos": "adverb", "tip":  "" },
-{ "id": "v020", "unit": "形容詞-基本", "jp": "驚く", "en": "surprised", "pos": "adjective", "tip":  "" },
-{ "id": "v021", "unit": "形容詞-基本", "jp": "有名な", "en": "famous", "pos": "adjective", "tip":  "" },
-{ "id": "v022", "unit": "前置詞-基本", "jp": "～なしで", "en": "without", "pos": "preposition", "tip":  "" },
-{ "id": "v023", "unit": "名詞-基本", "jp": "文化", "en": "culture", "pos": "noun", "tip":  "" },
-{ "id": "v024", "unit": "名詞-基本", "jp": "自然", "en": "nature", "pos": "noun", "tip":  "" },
-{ "id": "v025", "unit": "代名詞-基本", "jp": "お互いに", "en": "each other", "pos": "pronoun", "tip":  "" },
-{ "id": "v026", "unit": "名詞-基本", "jp": "服", "en": "clothes", "pos": "noun", "tip":  "" },
-{ "id": "v027", "unit": "名詞-基本", "jp": "理由", "en": "reason", "pos": "noun", "tip":  "" },
-{ "id": "v028", "unit": "名詞-基本", "jp": "野菜", "en": "vegetable", "pos": "noun", "tip":  "" },
-{ "id": "v029", "unit": "形容詞-基本", "jp": "変な", "en": "strange", "pos": "adjective", "tip":  "" },
-{ "id": "v030", "unit": "名詞-基本", "jp": "天気", "en": "weather", "pos": "noun", "tip":  "" },
-{ "id": "v031", "unit": "名詞-基本", "jp": "ちがい", "en": "difference", "pos": "noun", "tip":  "" },
-{ "id": "v032", "unit": "形容詞-基本", "jp": "生まれる", "en": "born", "pos": "adjective", "tip":  "" },
-{ "id": "v033", "unit": "動詞-基本", "jp": "経験する", "en": "experience", "pos": "verb", "tip":  "" },
-{ "id": "v034", "unit": "副詞-基本", "jp": "明日", "en": "tomorrow", "pos": "adverb", "tip":  "" },
-{ "id": "v035", "unit": "動詞-基本", "jp": "上達する", "en": "improve", "pos": "verb", "tip":  "" },
-{ "id": "v036", "unit": "形容詞-基本", "jp": "誇りに思う", "en": "proud", "pos": "adjective", "tip":  "" },
-{ "id": "v037", "unit": "名詞-基本", "jp": "～時間", "en": "hours", "pos": "noun", "tip":  "" },
-{ "id": "v038", "unit": "形容詞-基本", "jp": "危険な", "en": "dangerous", "pos": "adjective", "tip":  "" },
-{ "id": "v039", "unit": "動詞-基本", "jp": "共有する", "en": "share", "pos": "verb", "tip":  "" },
-{ "id": "v040", "unit": "数詞-基本", "jp": "千", "en": "thousand", "pos": "numeral", "tip":  "" },
-{ "id": "v041", "unit": "動詞-基本", "jp": "見つける（結果が出た）", "en": "find", "pos": "verb", "tip":  "" },
-{ "id": "v042", "unit": "名詞-基本", "jp": "方法、道", "en": "way", "pos": "noun", "tip":  "" },
-{ "id": "v043", "unit": "名詞-基本", "jp": "国", "en": "country", "pos": "noun", "tip":  "" },
-{ "id": "v044", "unit": "名詞-基本", "jp": "場所", "en": "place", "pos": "noun", "tip":  "" },
-{ "id": "v045", "unit": "形容詞-基本", "jp": "大きい", "en": "large", "pos": "adjective", "tip":  "" },
-{ "id": "v046", "unit": "動詞-基本", "jp": "保つ", "en": "keep", "pos": "verb", "tip":  "" },
-{ "id": "v047", "unit": "名詞-基本", "jp": "希望", "en": "hope", "pos": "noun", "tip":  "" },
-{ "id": "v048", "unit": "形容詞-基本", "jp": "疲れる", "en": "tired", "pos": "adjective", "tip":  "" },
-{ "id": "v049", "unit": "動詞-基本", "jp": "到着する", "en": "arrive", "pos": "verb", "tip":  "" },
-{ "id": "v050", "unit": "動詞-基本", "jp": "心配する", "en": "worry", "pos": "verb", "tip":  "" }
-
+    {
+      "id": "v001",
+      "unit": "動詞-基本",
+      "jp": "会う",
+      "en": "meet",
+      "pos": "verb",
+      "tip": ""
+    },
+    {
+      "id": "v002",
+      "unit": "動詞-基本",
+      "jp": "忘れる",
+      "en": "forget",
+      "pos": "verb",
+      "tip": ""
+    },
+    {
+      "id": "v003",
+      "unit": "形容詞-基本",
+      "jp": "怖い",
+      "en": "scary",
+      "pos": "adjective",
+      "tip": ""
+    },
+    {
+      "id": "v004",
+      "unit": "形容詞-基本",
+      "jp": "他の",
+      "en": "other",
+      "pos": "adjective",
+      "tip": ""
+    },
+    {
+      "id": "v005",
+      "unit": "動詞-基本",
+      "jp": "探す（探している最中）",
+      "en": "look for",
+      "pos": "verb",
+      "tip": ""
+    },
+    {
+      "id": "v006",
+      "unit": "動詞-基本",
+      "jp": "感じる",
+      "en": "feel",
+      "pos": "verb",
+      "tip": ""
+    },
+    {
+      "id": "v007",
+      "unit": "動詞-基本",
+      "jp": "尋ねる",
+      "en": "ask",
+      "pos": "verb",
+      "tip": ""
+    },
+    {
+      "id": "v008",
+      "unit": "形容詞-基本",
+      "jp": "わくわくする",
+      "en": "excited",
+      "pos": "adjective",
+      "tip": ""
+    },
+    {
+      "id": "v009",
+      "unit": "形容詞-基本",
+      "jp": "大切な",
+      "en": "important",
+      "pos": "adjective",
+      "tip": ""
+    },
+    {
+      "id": "v010",
+      "unit": "前置詞-基本",
+      "jp": "周りに",
+      "en": "around",
+      "pos": "preposition",
+      "tip": ""
+    },
+    {
+      "id": "v011",
+      "unit": "形容詞-基本",
+      "jp": "同じ",
+      "en": "same",
+      "pos": "adjective",
+      "tip": ""
+    },
+    {
+      "id": "v012",
+      "unit": "副詞-基本",
+      "jp": "決して～ない",
+      "en": "never",
+      "pos": "adverb",
+      "tip": ""
+    },
+    {
+      "id": "v013",
+      "unit": "形容詞-基本",
+      "jp": "もちろん",
+      "en": "sure",
+      "pos": "adjective",
+      "tip": ""
+    },
+    {
+      "id": "v014",
+      "unit": "代名詞-基本",
+      "jp": "両方",
+      "en": "both",
+      "pos": "pronoun",
+      "tip": ""
+    },
+    {
+      "id": "v015",
+      "unit": "副詞-基本",
+      "jp": "離れて",
+      "en": "away",
+      "pos": "adverb",
+      "tip": ""
+    },
+    {
+      "id": "v016",
+      "unit": "動詞-基本",
+      "jp": "出発する",
+      "en": "leave",
+      "pos": "verb",
+      "tip": ""
+    },
+    {
+      "id": "v017",
+      "unit": "動詞-基本",
+      "jp": "思い出す",
+      "en": "remember",
+      "pos": "verb",
+      "tip": ""
+    },
+    {
+      "id": "v018",
+      "unit": "名詞-基本",
+      "jp": "問題",
+      "en": "problem",
+      "pos": "noun",
+      "tip": ""
+    },
+    {
+      "id": "v019",
+      "unit": "副詞-基本",
+      "jp": "十分に",
+      "en": "enough",
+      "pos": "adverb",
+      "tip": ""
+    },
+    {
+      "id": "v020",
+      "unit": "形容詞-基本",
+      "jp": "驚く",
+      "en": "surprised",
+      "pos": "adjective",
+      "tip": ""
+    },
+    {
+      "id": "v021",
+      "unit": "形容詞-基本",
+      "jp": "有名な",
+      "en": "famous",
+      "pos": "adjective",
+      "tip": ""
+    },
+    {
+      "id": "v022",
+      "unit": "前置詞-基本",
+      "jp": "～なしで",
+      "en": "without",
+      "pos": "preposition",
+      "tip": ""
+    },
+    {
+      "id": "v023",
+      "unit": "名詞-基本",
+      "jp": "文化",
+      "en": "culture",
+      "pos": "noun",
+      "tip": ""
+    },
+    {
+      "id": "v024",
+      "unit": "名詞-基本",
+      "jp": "自然",
+      "en": "nature",
+      "pos": "noun",
+      "tip": ""
+    },
+    {
+      "id": "v025",
+      "unit": "代名詞-基本",
+      "jp": "お互いに",
+      "en": "each other",
+      "pos": "pronoun",
+      "tip": ""
+    },
+    {
+      "id": "v026",
+      "unit": "名詞-基本",
+      "jp": "服",
+      "en": "clothes",
+      "pos": "noun",
+      "tip": ""
+    },
+    {
+      "id": "v027",
+      "unit": "名詞-基本",
+      "jp": "理由",
+      "en": "reason",
+      "pos": "noun",
+      "tip": ""
+    },
+    {
+      "id": "v028",
+      "unit": "名詞-基本",
+      "jp": "野菜",
+      "en": "vegetable",
+      "pos": "noun",
+      "tip": ""
+    },
+    {
+      "id": "v029",
+      "unit": "形容詞-基本",
+      "jp": "変な",
+      "en": "strange",
+      "pos": "adjective",
+      "tip": ""
+    },
+    {
+      "id": "v030",
+      "unit": "名詞-基本",
+      "jp": "天気",
+      "en": "weather",
+      "pos": "noun",
+      "tip": ""
+    },
+    {
+      "id": "v031",
+      "unit": "名詞-基本",
+      "jp": "ちがい",
+      "en": "difference",
+      "pos": "noun",
+      "tip": ""
+    },
+    {
+      "id": "v032",
+      "unit": "形容詞-基本",
+      "jp": "生まれる",
+      "en": "born",
+      "pos": "adjective",
+      "tip": ""
+    },
+    {
+      "id": "v033",
+      "unit": "動詞-基本",
+      "jp": "経験する",
+      "en": "experience",
+      "pos": "verb",
+      "tip": ""
+    },
+    {
+      "id": "v034",
+      "unit": "副詞-基本",
+      "jp": "明日",
+      "en": "tomorrow",
+      "pos": "adverb",
+      "tip": ""
+    },
+    {
+      "id": "v035",
+      "unit": "動詞-基本",
+      "jp": "上達する",
+      "en": "improve",
+      "pos": "verb",
+      "tip": ""
+    },
+    {
+      "id": "v036",
+      "unit": "形容詞-基本",
+      "jp": "誇りに思う",
+      "en": "proud",
+      "pos": "adjective",
+      "tip": ""
+    },
+    {
+      "id": "v037",
+      "unit": "名詞-基本",
+      "jp": "～時間",
+      "en": "hours",
+      "pos": "noun",
+      "tip": ""
+    },
+    {
+      "id": "v038",
+      "unit": "形容詞-基本",
+      "jp": "危険な",
+      "en": "dangerous",
+      "pos": "adjective",
+      "tip": ""
+    },
+    {
+      "id": "v039",
+      "unit": "動詞-基本",
+      "jp": "共有する",
+      "en": "share",
+      "pos": "verb",
+      "tip": ""
+    },
+    {
+      "id": "v040",
+      "unit": "数詞-基本",
+      "jp": "千",
+      "en": "thousand",
+      "pos": "numeral",
+      "tip": ""
+    },
+    {
+      "id": "v041",
+      "unit": "動詞-基本",
+      "jp": "見つける（結果が出た）",
+      "en": "find",
+      "pos": "verb",
+      "tip": ""
+    },
+    {
+      "id": "v042",
+      "unit": "名詞-基本",
+      "jp": "方法、道",
+      "en": "way",
+      "pos": "noun",
+      "tip": ""
+    },
+    {
+      "id": "v043",
+      "unit": "名詞-基本",
+      "jp": "国",
+      "en": "country",
+      "pos": "noun",
+      "tip": ""
+    },
+    {
+      "id": "v044",
+      "unit": "名詞-基本",
+      "jp": "場所",
+      "en": "place",
+      "pos": "noun",
+      "tip": ""
+    },
+    {
+      "id": "v045",
+      "unit": "形容詞-基本",
+      "jp": "大きい",
+      "en": "large",
+      "pos": "adjective",
+      "tip": ""
+    },
+    {
+      "id": "v046",
+      "unit": "動詞-基本",
+      "jp": "保つ",
+      "en": "keep",
+      "pos": "verb",
+      "tip": ""
+    },
+    {
+      "id": "v047",
+      "unit": "名詞-基本",
+      "jp": "希望",
+      "en": "hope",
+      "pos": "noun",
+      "tip": ""
+    },
+    {
+      "id": "v048",
+      "unit": "形容詞-基本",
+      "jp": "疲れる",
+      "en": "tired",
+      "pos": "adjective",
+      "tip": ""
+    },
+    {
+      "id": "v049",
+      "unit": "動詞-基本",
+      "jp": "到着する",
+      "en": "arrive",
+      "pos": "verb",
+      "tip": ""
+    },
+    {
+      "id": "v050",
+      "unit": "動詞-基本",
+      "jp": "心配する",
+      "en": "worry",
+      "pos": "verb",
+      "tip": ""
+    }
   ]
 }

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -160,7 +160,7 @@
       if (!res.ok) throw new Error("質問ファイルの読み込みに失敗: " + res.status);
       const data = await res.json();
       // 互換: 旧形式 questions は並べ替え扱い
-      BANK_REORDER = (data.questions||data.reorder||[]).map(q=>({type:'reorder', id:q.id||null, unit:q.unit||null, jp:q.jp, en:q.en, chunks:q.chunks, tip:q.tip||''}));
+      BANK_REORDER = (data.questions||data.reorder||[]).map(q=>({type:'reorder', id:q.id||null, unit:q.unit||null, jp:q.jp, en:q.en, chunks:q.chunks, wrong:q.wrong||[], tip:q.tip||''}));
       BANK_VOCAB   = (data.vocab||[]).map(v=>({type:'vocab', id:v.id||null, unit:v.unit||null, jp:v.jp, en:v.en, tip:v.tip||'', pos:v.pos||''}));
     }
 
@@ -190,6 +190,7 @@
     const normalizeSpaces = s=> s.replace(new RegExp(`[${NBSP}\\s]+`,'g'),' ').trim();
     const normalizeEndPunc = (s, keep=false)=> keep ? s.replace(/\s+([.,!?])/g, "$1") : s.replace(/\s*[.,!?]$/,'');
     const normalizeWord = s=> normalizeSpaces(s).toLowerCase();
+    const HARD_STREAK = 3;
     const nowISO = ()=> new Date().toISOString();
 
     async function postJSON(url, data, timeoutMs=6000){
@@ -212,7 +213,7 @@
 
       // レビュー用デッキに流し込む（既存ロジック流用）
       window.__REVIEW_DECK__ = customDeck.map(q=>({ ...q }));
-      state.order = [...window.__REVIEW_DECK__.keys()].map(i=>({idx:i, bucket:null}));
+      state.order = [...window.__REVIEW_DECK__.keys()].map(i=>({idx:i, bucket:null, streak:0}));
       state.mode = 'review';
       // 表示UIを合わせる（並べ替え/単語）
       state.qType = (window.__REVIEW_DECK__[0]?.type) || state.qType;
@@ -290,7 +291,7 @@
 
       for(let i=0;i<deckArr.length;i++){
         const s = stats[i];
-        if(!s){ bucketB.push(i); continue; }
+        if(!s){ bucketB.push({idx:i, streak:0}); continue; }
         const streak = s.streak||0;
         const ans = s.answered||0;
         const ok = s.correct||0;
@@ -298,7 +299,7 @@
         if(streak>0){
           bucketA.push({ idx:i, streak, accuracy, rand:Math.random() });
         }else{
-          bucketB.push(i);
+          bucketB.push({idx:i, streak:0});
         }
       }
 
@@ -310,19 +311,20 @@
       bucketA.sort(compareA);
       if(bucketA.length>0){
         const picked = bucketA.shift();
-        order.push({ idx:picked.idx, bucket:'A' });
+        order.push({ idx:picked.idx, bucket:'A', streak:picked.streak });
       }
 
       const B = shuffle(bucketB); // ランダム
       while(order.length < n && B.length){
-        order.push({ idx:B.shift(), bucket:'B' });
+        const b = B.shift();
+        order.push({ idx:b.idx, bucket:'B', streak:b.streak });
       }
 
       bucketA.forEach(x=>x.rand=Math.random());
       bucketA.sort(compareA);
       while(order.length < n && bucketA.length){
         const next = bucketA.shift();
-        order.push({ idx:next.idx, bucket:'A' });
+        order.push({ idx:next.idx, bucket:'A', streak:next.streak });
       }
 
       return order;
@@ -432,11 +434,11 @@
       if(state.mode==='review'){
         const ord = buildOrderFromWrong(state.reviewStrategy||'all');
         if(ord.length===0){ alert('復習する問題がありません。まずは通常モードで間違いをためましょう。'); show('setup'); return; }
-        state.order = ord.map(i=>({idx:i, bucket:null}));
+        state.order = ord.map(i=>({idx:i, bucket:null, streak:0}));
       }else if(state.mode==='weak'){
         const ord = buildOrderWeak(state.weakWindowDays||7);
         if(ord.length===0){ alert('弱点候補が見つかりません（最近のデータが不足）。通常モードで解いてデータを増やしましょう。'); show('setup'); return; }
-        state.order = ord.map(i=>({idx:i, bucket:null}));
+        state.order = ord.map(i=>({idx:i, bucket:null, streak:0}));
       }else{
         state.order = await buildOrderFromBank();
       }
@@ -470,7 +472,12 @@
         $('#prompt').innerHTML = basePrompt;
         $('#btn-hint').disabled = !q.tip;
         const target=$('#target'); const bank=$('#bank'); target.innerHTML=''; bank.innerHTML='';
-        const chunks = shuffle(q.chunks.slice());
+        let chunks = q.chunks.slice();
+        if(entry.streak >= HARD_STREAK && q.wrong && q.wrong.length>0){
+          const w = q.wrong[Math.floor(Math.random()*q.wrong.length)];
+          chunks = chunks.concat(w);
+        }
+        chunks = shuffle(chunks);
         chunks.forEach((c,i)=>{
           const chip=document.createElement('button'); chip.className='chip'; chip.setAttribute('data-text',c); chip.textContent=`${i+1}. ${c}`;
           chip.onclick=()=>placeChip(chip); bank.appendChild(chip);

--- a/questions.json
+++ b/questions.json
@@ -1,81 +1,753 @@
 {
-  "meta": { "version": 2, "lang": "ja-en", "note": "並べ替え(questions)＋単語(vocab) を同居" },
-
+  "meta": {
+    "version": 2,
+    "lang": "ja-en",
+    "note": "並べ替え(questions)＋単語(vocab) を同居"
+  },
   "questions": [
-  { "id": "r001", "unit": "present-simple", "jp": "彼は放課後にサッカーをします。", "en": "He plays soccer after school.", "chunks": ["he","plays","soccer","after school","."], "tip": "三単現: He plays（sを忘れずに）" },
-  { "id": "r002", "unit": "present-continuous-q", "jp": "あなたは今宿題をしていますか。", "en": "Are you doing your homework now?", "chunks": ["are","you","doing","your homework","now","?"], "tip": "進行形の疑問: Are you ～?" },
-  { "id": "r003", "unit": "past-simple", "jp": "私は昨日その博物館に行きました。", "en": "I went to the museum yesterday.", "chunks": ["i","went","to the museum","yesterday","."], "tip": "go の過去形は went" },
-  { "id": "r004", "unit": "comparative", "jp": "この本はあの本よりおもしろい。", "en": "This book is more interesting than that one.", "chunks": ["this book","is","more interesting","than that one","."], "tip": "比較級: more … than ～" },
-  { "id": "r005", "unit": "there-is", "jp": "机の下に猫が一匹います。", "en": "There is a cat under the desk.", "chunks": ["there is","a cat","under the desk","."], "tip": "存在文: There is/are" },
-  { "id": "r006", "unit": "present-3sg", "jp": "彼女は毎朝朝ごはんを食べます。", "en": "She has breakfast every morning.", "chunks": ["she","has","breakfast","every morning","."], "tip": "have → has（3単現）" },
-  { "id": "r007", "unit": "present-continuous", "jp": "私は英語を勉強しているところです。", "en": "I am studying English.", "chunks": ["i","am","studying","english","."], "tip": "be + -ing で進行形" },
-  { "id": "r008", "unit": "past-simple-q", "jp": "あなたは昨日映画を見ましたか。", "en": "Did you watch a movie yesterday?", "chunks": ["did","you","watch","a movie","yesterday","?"], "tip": "過去の疑問: Did + 主語 + 動詞原形" },
-  { "id": "r009", "unit": "present-simple", "jp": "私は毎日朝ごはんを食べます。", "en": "I eat breakfast every day.", "chunks": ["i","eat","breakfast","every day","."], "tip": "一般動詞の現在形: 主語 + 動詞原形" },
-  { "id": "r010", "unit": "present-simple-q", "jp": "あなたはサッカーが好きですか。", "en": "Do you like soccer?", "chunks": ["do","you","like","soccer","?"], "tip": "一般動詞の疑問文: Do + 主語 + 動詞原形" },
-  { "id": "r011", "unit": "be-verb", "jp": "彼女は生徒です。", "en": "She is a student.", "chunks": ["she","is","a student","."], "tip": "be動詞の肯定文: 主語 + be動詞 + 補語" },
-  { "id": "r012", "unit": "be-verb-neg", "jp": "私は先生ではありません。", "en": "I am not a teacher.", "chunks": ["i","am","not","a teacher","."], "tip": "be動詞の否定文: 主語 + be動詞 + not + 補語" },
-  { "id": "r013", "unit": "be-verb-q", "jp": "彼はアメリカ出身ですか。", "en": "Is he from America?", "chunks": ["is","he","from","america","?"], "tip": "be動詞の疑問文: Be動詞 + 主語 + 補語" },
-  { "id": "r014", "unit": "present-cont-q", "jp": "彼らはいまサッカーをしていますか。", "en": "Are they playing soccer now?", "chunks": ["are","they","playing","soccer","now","?"], "tip": "現在進行形の疑問文: Be動詞 + 主語 + 動詞ing" },
-  { "id": "r015", "unit": "present-cont-neg", "jp": "彼はテレビを見ていません。", "en": "He is not watching TV.", "chunks": ["he","is","not","watching","tv","."], "tip": "現在進行形の否定文: 主語 + be動詞 + not + 動詞ing" },
-  { "id": "r016", "unit": "present-simple-q", "jp": "あなたのお父さんは日曜日にテニスをしますか。", "en": "Does your father play tennis on Sunday?", "chunks": ["does","your father","play","tennis","on sunday","?"], "tip": "三単現の疑問文: Does + 主語 + 動詞原形" },
-  { "id": "r017", "unit": "present-simple-neg", "jp": "私は図書館で勉強しません。", "en": "I do not study in the library.", "chunks": ["i","do not","study","in the library","."], "tip": "一般動詞の否定文: do not + 動詞原形" },
-  { "id": "r018", "unit": "be-verb-q", "jp": "これらの本はあなたのですか。", "en": "Are these books yours?", "chunks": ["are","these books","yours","?"], "tip": "be動詞の疑問文（複数）: Are + 複数主語" },
-  { "id": "r019", "unit": "present-cont-q", "jp": "あなたのお姉さんはいまピアノを弾いていますか。", "en": "Is your sister playing the piano now?", "chunks": ["is","your sister","playing","the piano","now","?"], "tip": "現在進行形の疑問文: Be動詞 + 主語 + 動詞ing" },
-  { "id": "r020", "unit": "there-are", "jp": "机の上に3本のえんぴつがあります。", "en": "There are three pencils on the desk.", "chunks": ["there are","three pencils","on the desk","."], "tip": "存在文（複数）: There are + 複数名詞" }
-
+    {
+      "id": "r001",
+      "unit": "present-simple",
+      "jp": "彼は放課後にサッカーをします。",
+      "en": "He plays soccer after school.",
+      "chunks": [
+        "he",
+        "plays",
+        "soccer",
+        "after school",
+        "."
+      ],
+      "tip": "三単現: He plays（sを忘れずに）",
+      "wrong": [
+        "is"
+      ]
+    },
+    {
+      "id": "r002",
+      "unit": "present-continuous-q",
+      "jp": "あなたは今宿題をしていますか。",
+      "en": "Are you doing your homework now?",
+      "chunks": [
+        "are",
+        "you",
+        "doing",
+        "your homework",
+        "now",
+        "?"
+      ],
+      "tip": "進行形の疑問: Are you ～?",
+      "wrong": [
+        "has"
+      ]
+    },
+    {
+      "id": "r003",
+      "unit": "past-simple",
+      "jp": "私は昨日その博物館に行きました。",
+      "en": "I went to the museum yesterday.",
+      "chunks": [
+        "i",
+        "went",
+        "to the museum",
+        "yesterday",
+        "."
+      ],
+      "tip": "go の過去形は went",
+      "wrong": [
+        "am"
+      ]
+    },
+    {
+      "id": "r004",
+      "unit": "comparative",
+      "jp": "この本はあの本よりおもしろい。",
+      "en": "This book is more interesting than that one.",
+      "chunks": [
+        "this book",
+        "is",
+        "more interesting",
+        "than that one",
+        "."
+      ],
+      "tip": "比較級: more … than ～",
+      "wrong": [
+        "do"
+      ]
+    },
+    {
+      "id": "r005",
+      "unit": "there-is",
+      "jp": "机の下に猫が一匹います。",
+      "en": "There is a cat under the desk.",
+      "chunks": [
+        "there is",
+        "a cat",
+        "under the desk",
+        "."
+      ],
+      "tip": "存在文: There is/are",
+      "wrong": [
+        "does"
+      ]
+    },
+    {
+      "id": "r006",
+      "unit": "present-3sg",
+      "jp": "彼女は毎朝朝ごはんを食べます。",
+      "en": "She has breakfast every morning.",
+      "chunks": [
+        "she",
+        "has",
+        "breakfast",
+        "every morning",
+        "."
+      ],
+      "tip": "have → has（3単現）",
+      "wrong": [
+        "are"
+      ]
+    },
+    {
+      "id": "r007",
+      "unit": "present-continuous",
+      "jp": "私は英語を勉強しているところです。",
+      "en": "I am studying English.",
+      "chunks": [
+        "i",
+        "am",
+        "studying",
+        "english",
+        "."
+      ],
+      "tip": "be + -ing で進行形",
+      "wrong": [
+        "does"
+      ]
+    },
+    {
+      "id": "r008",
+      "unit": "past-simple-q",
+      "jp": "あなたは昨日映画を見ましたか。",
+      "en": "Did you watch a movie yesterday?",
+      "chunks": [
+        "did",
+        "you",
+        "watch",
+        "a movie",
+        "yesterday",
+        "?"
+      ],
+      "tip": "過去の疑問: Did + 主語 + 動詞原形",
+      "wrong": [
+        "is"
+      ]
+    },
+    {
+      "id": "r009",
+      "unit": "present-simple",
+      "jp": "私は毎日朝ごはんを食べます。",
+      "en": "I eat breakfast every day.",
+      "chunks": [
+        "i",
+        "eat",
+        "breakfast",
+        "every day",
+        "."
+      ],
+      "tip": "一般動詞の現在形: 主語 + 動詞原形",
+      "wrong": [
+        "is"
+      ]
+    },
+    {
+      "id": "r010",
+      "unit": "present-simple-q",
+      "jp": "あなたはサッカーが好きですか。",
+      "en": "Do you like soccer?",
+      "chunks": [
+        "do",
+        "you",
+        "like",
+        "soccer",
+        "?"
+      ],
+      "tip": "一般動詞の疑問文: Do + 主語 + 動詞原形",
+      "wrong": [
+        "am"
+      ]
+    },
+    {
+      "id": "r011",
+      "unit": "be-verb",
+      "jp": "彼女は生徒です。",
+      "en": "She is a student.",
+      "chunks": [
+        "she",
+        "is",
+        "a student",
+        "."
+      ],
+      "tip": "be動詞の肯定文: 主語 + be動詞 + 補語",
+      "wrong": [
+        "do"
+      ]
+    },
+    {
+      "id": "r012",
+      "unit": "be-verb-neg",
+      "jp": "私は先生ではありません。",
+      "en": "I am not a teacher.",
+      "chunks": [
+        "i",
+        "am",
+        "not",
+        "a teacher",
+        "."
+      ],
+      "tip": "be動詞の否定文: 主語 + be動詞 + not + 補語",
+      "wrong": [
+        "does"
+      ]
+    },
+    {
+      "id": "r013",
+      "unit": "be-verb-q",
+      "jp": "彼はアメリカ出身ですか。",
+      "en": "Is he from America?",
+      "chunks": [
+        "is",
+        "he",
+        "from",
+        "america",
+        "?"
+      ],
+      "tip": "be動詞の疑問文: Be動詞 + 主語 + 補語",
+      "wrong": [
+        "do"
+      ]
+    },
+    {
+      "id": "r014",
+      "unit": "present-cont-q",
+      "jp": "彼らはいまサッカーをしていますか。",
+      "en": "Are they playing soccer now?",
+      "chunks": [
+        "are",
+        "they",
+        "playing",
+        "soccer",
+        "now",
+        "?"
+      ],
+      "tip": "現在進行形の疑問文: Be動詞 + 主語 + 動詞ing",
+      "wrong": [
+        "has"
+      ]
+    },
+    {
+      "id": "r015",
+      "unit": "present-cont-neg",
+      "jp": "彼はテレビを見ていません。",
+      "en": "He is not watching TV.",
+      "chunks": [
+        "he",
+        "is",
+        "not",
+        "watching",
+        "tv",
+        "."
+      ],
+      "tip": "現在進行形の否定文: 主語 + be動詞 + not + 動詞ing",
+      "wrong": [
+        "do"
+      ]
+    },
+    {
+      "id": "r016",
+      "unit": "present-simple-q",
+      "jp": "あなたのお父さんは日曜日にテニスをしますか。",
+      "en": "Does your father play tennis on Sunday?",
+      "chunks": [
+        "does",
+        "your father",
+        "play",
+        "tennis",
+        "on sunday",
+        "?"
+      ],
+      "tip": "三単現の疑問文: Does + 主語 + 動詞原形",
+      "wrong": [
+        "am"
+      ]
+    },
+    {
+      "id": "r017",
+      "unit": "present-simple-neg",
+      "jp": "私は図書館で勉強しません。",
+      "en": "I do not study in the library.",
+      "chunks": [
+        "i",
+        "do not",
+        "study",
+        "in the library",
+        "."
+      ],
+      "tip": "一般動詞の否定文: do not + 動詞原形",
+      "wrong": [
+        "is"
+      ]
+    },
+    {
+      "id": "r018",
+      "unit": "be-verb-q",
+      "jp": "これらの本はあなたのですか。",
+      "en": "Are these books yours?",
+      "chunks": [
+        "are",
+        "these books",
+        "yours",
+        "?"
+      ],
+      "tip": "be動詞の疑問文（複数）: Are + 複数主語",
+      "wrong": [
+        "does"
+      ]
+    },
+    {
+      "id": "r019",
+      "unit": "present-cont-q",
+      "jp": "あなたのお姉さんはいまピアノを弾いていますか。",
+      "en": "Is your sister playing the piano now?",
+      "chunks": [
+        "is",
+        "your sister",
+        "playing",
+        "the piano",
+        "now",
+        "?"
+      ],
+      "tip": "現在進行形の疑問文: Be動詞 + 主語 + 動詞ing",
+      "wrong": [
+        "do"
+      ]
+    },
+    {
+      "id": "r020",
+      "unit": "there-are",
+      "jp": "机の上に3本のえんぴつがあります。",
+      "en": "There are three pencils on the desk.",
+      "chunks": [
+        "there are",
+        "three pencils",
+        "on the desk",
+        "."
+      ],
+      "tip": "存在文（複数）: There are + 複数名詞",
+      "wrong": [
+        "does"
+      ]
+    }
   ],
-
   "vocab": [
-{ "id": "v001", "unit": "動詞-基本", "jp": "会う", "en": "meet", "pos": "verb", "tip":  "" },
-{ "id": "v002", "unit": "動詞-基本", "jp": "忘れる", "en": "forget", "pos": "verb", "tip":  "" },
-{ "id": "v003", "unit": "形容詞-基本", "jp": "怖い", "en": "scary", "pos": "adjective", "tip":  "" },
-{ "id": "v004", "unit": "形容詞-基本", "jp": "他の", "en": "other", "pos": "adjective", "tip":  "" },
-{ "id": "v005", "unit": "動詞-基本", "jp": "探す（探している最中）", "en": "look for", "pos": "verb", "tip":  "" },
-{ "id": "v006", "unit": "動詞-基本", "jp": "感じる", "en": "feel", "pos": "verb", "tip":  "" },
-{ "id": "v007", "unit": "動詞-基本", "jp": "尋ねる", "en": "ask", "pos": "verb", "tip":  "" },
-{ "id": "v008", "unit": "形容詞-基本", "jp": "わくわくする", "en": "excited", "pos": "adjective", "tip":  "" },
-{ "id": "v009", "unit": "形容詞-基本", "jp": "大切な", "en": "important", "pos": "adjective", "tip":  "" },
-{ "id": "v010", "unit": "前置詞-基本", "jp": "周りに", "en": "around", "pos": "preposition", "tip":  "" },
-{ "id": "v011", "unit": "形容詞-基本", "jp": "同じ", "en": "same", "pos": "adjective", "tip":  "" },
-{ "id": "v012", "unit": "副詞-基本", "jp": "決して～ない", "en": "never", "pos": "adverb", "tip":  "" },
-{ "id": "v013", "unit": "形容詞-基本", "jp": "もちろん", "en": "sure", "pos": "adjective", "tip":  "" },
-{ "id": "v014", "unit": "代名詞-基本", "jp": "両方", "en": "both", "pos": "pronoun", "tip":  "" },
-{ "id": "v015", "unit": "副詞-基本", "jp": "離れて", "en": "away", "pos": "adverb", "tip":  "" },
-{ "id": "v016", "unit": "動詞-基本", "jp": "出発する", "en": "leave", "pos": "verb", "tip":  "" },
-{ "id": "v017", "unit": "動詞-基本", "jp": "思い出す", "en": "remember", "pos": "verb", "tip":  "" },
-{ "id": "v018", "unit": "名詞-基本", "jp": "問題", "en": "problem", "pos": "noun", "tip":  "" },
-{ "id": "v019", "unit": "副詞-基本", "jp": "十分に", "en": "enough", "pos": "adverb", "tip":  "" },
-{ "id": "v020", "unit": "形容詞-基本", "jp": "驚く", "en": "surprised", "pos": "adjective", "tip":  "" },
-{ "id": "v021", "unit": "形容詞-基本", "jp": "有名な", "en": "famous", "pos": "adjective", "tip":  "" },
-{ "id": "v022", "unit": "前置詞-基本", "jp": "～なしで", "en": "without", "pos": "preposition", "tip":  "" },
-{ "id": "v023", "unit": "名詞-基本", "jp": "文化", "en": "culture", "pos": "noun", "tip":  "" },
-{ "id": "v024", "unit": "名詞-基本", "jp": "自然", "en": "nature", "pos": "noun", "tip":  "" },
-{ "id": "v025", "unit": "代名詞-基本", "jp": "お互いに", "en": "each other", "pos": "pronoun", "tip":  "" },
-{ "id": "v026", "unit": "名詞-基本", "jp": "服", "en": "clothes", "pos": "noun", "tip":  "" },
-{ "id": "v027", "unit": "名詞-基本", "jp": "理由", "en": "reason", "pos": "noun", "tip":  "" },
-{ "id": "v028", "unit": "名詞-基本", "jp": "野菜", "en": "vegetable", "pos": "noun", "tip":  "" },
-{ "id": "v029", "unit": "形容詞-基本", "jp": "変な", "en": "strange", "pos": "adjective", "tip":  "" },
-{ "id": "v030", "unit": "名詞-基本", "jp": "天気", "en": "weather", "pos": "noun", "tip":  "" },
-{ "id": "v031", "unit": "名詞-基本", "jp": "ちがい", "en": "difference", "pos": "noun", "tip":  "" },
-{ "id": "v032", "unit": "形容詞-基本", "jp": "生まれる", "en": "born", "pos": "adjective", "tip":  "" },
-{ "id": "v033", "unit": "動詞-基本", "jp": "経験する", "en": "experience", "pos": "verb", "tip":  "" },
-{ "id": "v034", "unit": "副詞-基本", "jp": "明日", "en": "tomorrow", "pos": "adverb", "tip":  "" },
-{ "id": "v035", "unit": "動詞-基本", "jp": "上達する", "en": "improve", "pos": "verb", "tip":  "" },
-{ "id": "v036", "unit": "形容詞-基本", "jp": "誇りに思う", "en": "proud", "pos": "adjective", "tip":  "" },
-{ "id": "v037", "unit": "名詞-基本", "jp": "～時間", "en": "hours", "pos": "noun", "tip":  "" },
-{ "id": "v038", "unit": "形容詞-基本", "jp": "危険な", "en": "dangerous", "pos": "adjective", "tip":  "" },
-{ "id": "v039", "unit": "動詞-基本", "jp": "共有する", "en": "share", "pos": "verb", "tip":  "" },
-{ "id": "v040", "unit": "数詞-基本", "jp": "千", "en": "thousand", "pos": "numeral", "tip":  "" },
-{ "id": "v041", "unit": "動詞-基本", "jp": "見つける（結果が出た）", "en": "find", "pos": "verb", "tip":  "" },
-{ "id": "v042", "unit": "名詞-基本", "jp": "方法、道", "en": "way", "pos": "noun", "tip":  "" },
-{ "id": "v043", "unit": "名詞-基本", "jp": "国", "en": "country", "pos": "noun", "tip":  "" },
-{ "id": "v044", "unit": "名詞-基本", "jp": "場所", "en": "place", "pos": "noun", "tip":  "" },
-{ "id": "v045", "unit": "形容詞-基本", "jp": "大きい", "en": "large", "pos": "adjective", "tip":  "" },
-{ "id": "v046", "unit": "動詞-基本", "jp": "保つ", "en": "keep", "pos": "verb", "tip":  "" },
-{ "id": "v047", "unit": "名詞-基本", "jp": "希望", "en": "hope", "pos": "noun", "tip":  "" },
-{ "id": "v048", "unit": "形容詞-基本", "jp": "疲れる", "en": "tired", "pos": "adjective", "tip":  "" },
-{ "id": "v049", "unit": "動詞-基本", "jp": "到着する", "en": "arrive", "pos": "verb", "tip":  "" },
-{ "id": "v050", "unit": "動詞-基本", "jp": "心配する", "en": "worry", "pos": "verb", "tip":  "" }
-
+    {
+      "id": "v001",
+      "unit": "動詞-基本",
+      "jp": "会う",
+      "en": "meet",
+      "pos": "verb",
+      "tip": ""
+    },
+    {
+      "id": "v002",
+      "unit": "動詞-基本",
+      "jp": "忘れる",
+      "en": "forget",
+      "pos": "verb",
+      "tip": ""
+    },
+    {
+      "id": "v003",
+      "unit": "形容詞-基本",
+      "jp": "怖い",
+      "en": "scary",
+      "pos": "adjective",
+      "tip": ""
+    },
+    {
+      "id": "v004",
+      "unit": "形容詞-基本",
+      "jp": "他の",
+      "en": "other",
+      "pos": "adjective",
+      "tip": ""
+    },
+    {
+      "id": "v005",
+      "unit": "動詞-基本",
+      "jp": "探す（探している最中）",
+      "en": "look for",
+      "pos": "verb",
+      "tip": ""
+    },
+    {
+      "id": "v006",
+      "unit": "動詞-基本",
+      "jp": "感じる",
+      "en": "feel",
+      "pos": "verb",
+      "tip": ""
+    },
+    {
+      "id": "v007",
+      "unit": "動詞-基本",
+      "jp": "尋ねる",
+      "en": "ask",
+      "pos": "verb",
+      "tip": ""
+    },
+    {
+      "id": "v008",
+      "unit": "形容詞-基本",
+      "jp": "わくわくする",
+      "en": "excited",
+      "pos": "adjective",
+      "tip": ""
+    },
+    {
+      "id": "v009",
+      "unit": "形容詞-基本",
+      "jp": "大切な",
+      "en": "important",
+      "pos": "adjective",
+      "tip": ""
+    },
+    {
+      "id": "v010",
+      "unit": "前置詞-基本",
+      "jp": "周りに",
+      "en": "around",
+      "pos": "preposition",
+      "tip": ""
+    },
+    {
+      "id": "v011",
+      "unit": "形容詞-基本",
+      "jp": "同じ",
+      "en": "same",
+      "pos": "adjective",
+      "tip": ""
+    },
+    {
+      "id": "v012",
+      "unit": "副詞-基本",
+      "jp": "決して～ない",
+      "en": "never",
+      "pos": "adverb",
+      "tip": ""
+    },
+    {
+      "id": "v013",
+      "unit": "形容詞-基本",
+      "jp": "もちろん",
+      "en": "sure",
+      "pos": "adjective",
+      "tip": ""
+    },
+    {
+      "id": "v014",
+      "unit": "代名詞-基本",
+      "jp": "両方",
+      "en": "both",
+      "pos": "pronoun",
+      "tip": ""
+    },
+    {
+      "id": "v015",
+      "unit": "副詞-基本",
+      "jp": "離れて",
+      "en": "away",
+      "pos": "adverb",
+      "tip": ""
+    },
+    {
+      "id": "v016",
+      "unit": "動詞-基本",
+      "jp": "出発する",
+      "en": "leave",
+      "pos": "verb",
+      "tip": ""
+    },
+    {
+      "id": "v017",
+      "unit": "動詞-基本",
+      "jp": "思い出す",
+      "en": "remember",
+      "pos": "verb",
+      "tip": ""
+    },
+    {
+      "id": "v018",
+      "unit": "名詞-基本",
+      "jp": "問題",
+      "en": "problem",
+      "pos": "noun",
+      "tip": ""
+    },
+    {
+      "id": "v019",
+      "unit": "副詞-基本",
+      "jp": "十分に",
+      "en": "enough",
+      "pos": "adverb",
+      "tip": ""
+    },
+    {
+      "id": "v020",
+      "unit": "形容詞-基本",
+      "jp": "驚く",
+      "en": "surprised",
+      "pos": "adjective",
+      "tip": ""
+    },
+    {
+      "id": "v021",
+      "unit": "形容詞-基本",
+      "jp": "有名な",
+      "en": "famous",
+      "pos": "adjective",
+      "tip": ""
+    },
+    {
+      "id": "v022",
+      "unit": "前置詞-基本",
+      "jp": "～なしで",
+      "en": "without",
+      "pos": "preposition",
+      "tip": ""
+    },
+    {
+      "id": "v023",
+      "unit": "名詞-基本",
+      "jp": "文化",
+      "en": "culture",
+      "pos": "noun",
+      "tip": ""
+    },
+    {
+      "id": "v024",
+      "unit": "名詞-基本",
+      "jp": "自然",
+      "en": "nature",
+      "pos": "noun",
+      "tip": ""
+    },
+    {
+      "id": "v025",
+      "unit": "代名詞-基本",
+      "jp": "お互いに",
+      "en": "each other",
+      "pos": "pronoun",
+      "tip": ""
+    },
+    {
+      "id": "v026",
+      "unit": "名詞-基本",
+      "jp": "服",
+      "en": "clothes",
+      "pos": "noun",
+      "tip": ""
+    },
+    {
+      "id": "v027",
+      "unit": "名詞-基本",
+      "jp": "理由",
+      "en": "reason",
+      "pos": "noun",
+      "tip": ""
+    },
+    {
+      "id": "v028",
+      "unit": "名詞-基本",
+      "jp": "野菜",
+      "en": "vegetable",
+      "pos": "noun",
+      "tip": ""
+    },
+    {
+      "id": "v029",
+      "unit": "形容詞-基本",
+      "jp": "変な",
+      "en": "strange",
+      "pos": "adjective",
+      "tip": ""
+    },
+    {
+      "id": "v030",
+      "unit": "名詞-基本",
+      "jp": "天気",
+      "en": "weather",
+      "pos": "noun",
+      "tip": ""
+    },
+    {
+      "id": "v031",
+      "unit": "名詞-基本",
+      "jp": "ちがい",
+      "en": "difference",
+      "pos": "noun",
+      "tip": ""
+    },
+    {
+      "id": "v032",
+      "unit": "形容詞-基本",
+      "jp": "生まれる",
+      "en": "born",
+      "pos": "adjective",
+      "tip": ""
+    },
+    {
+      "id": "v033",
+      "unit": "動詞-基本",
+      "jp": "経験する",
+      "en": "experience",
+      "pos": "verb",
+      "tip": ""
+    },
+    {
+      "id": "v034",
+      "unit": "副詞-基本",
+      "jp": "明日",
+      "en": "tomorrow",
+      "pos": "adverb",
+      "tip": ""
+    },
+    {
+      "id": "v035",
+      "unit": "動詞-基本",
+      "jp": "上達する",
+      "en": "improve",
+      "pos": "verb",
+      "tip": ""
+    },
+    {
+      "id": "v036",
+      "unit": "形容詞-基本",
+      "jp": "誇りに思う",
+      "en": "proud",
+      "pos": "adjective",
+      "tip": ""
+    },
+    {
+      "id": "v037",
+      "unit": "名詞-基本",
+      "jp": "～時間",
+      "en": "hours",
+      "pos": "noun",
+      "tip": ""
+    },
+    {
+      "id": "v038",
+      "unit": "形容詞-基本",
+      "jp": "危険な",
+      "en": "dangerous",
+      "pos": "adjective",
+      "tip": ""
+    },
+    {
+      "id": "v039",
+      "unit": "動詞-基本",
+      "jp": "共有する",
+      "en": "share",
+      "pos": "verb",
+      "tip": ""
+    },
+    {
+      "id": "v040",
+      "unit": "数詞-基本",
+      "jp": "千",
+      "en": "thousand",
+      "pos": "numeral",
+      "tip": ""
+    },
+    {
+      "id": "v041",
+      "unit": "動詞-基本",
+      "jp": "見つける（結果が出た）",
+      "en": "find",
+      "pos": "verb",
+      "tip": ""
+    },
+    {
+      "id": "v042",
+      "unit": "名詞-基本",
+      "jp": "方法、道",
+      "en": "way",
+      "pos": "noun",
+      "tip": ""
+    },
+    {
+      "id": "v043",
+      "unit": "名詞-基本",
+      "jp": "国",
+      "en": "country",
+      "pos": "noun",
+      "tip": ""
+    },
+    {
+      "id": "v044",
+      "unit": "名詞-基本",
+      "jp": "場所",
+      "en": "place",
+      "pos": "noun",
+      "tip": ""
+    },
+    {
+      "id": "v045",
+      "unit": "形容詞-基本",
+      "jp": "大きい",
+      "en": "large",
+      "pos": "adjective",
+      "tip": ""
+    },
+    {
+      "id": "v046",
+      "unit": "動詞-基本",
+      "jp": "保つ",
+      "en": "keep",
+      "pos": "verb",
+      "tip": ""
+    },
+    {
+      "id": "v047",
+      "unit": "名詞-基本",
+      "jp": "希望",
+      "en": "hope",
+      "pos": "noun",
+      "tip": ""
+    },
+    {
+      "id": "v048",
+      "unit": "形容詞-基本",
+      "jp": "疲れる",
+      "en": "tired",
+      "pos": "adjective",
+      "tip": ""
+    },
+    {
+      "id": "v049",
+      "unit": "動詞-基本",
+      "jp": "到着する",
+      "en": "arrive",
+      "pos": "verb",
+      "tip": ""
+    },
+    {
+      "id": "v050",
+      "unit": "動詞-基本",
+      "jp": "心配する",
+      "en": "worry",
+      "pos": "verb",
+      "tip": ""
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- extend question data with `wrong` choice array for shuffle questions
- track user streaks and inject random wrong options when streak threshold reached

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68c597a8ab08833383be9e95ccb0ea4c