### PR TITLE
Expand admin dashboard container width for large displays

### DIFF
--- a/app/static/admin.html
+++ b/app/static/admin.html
@@ -9,7 +9,7 @@
     *{ box-sizing:border-box }
     body{ margin:0; background:var(--bg); color:var(--text); font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,"Noto Sans JP",sans-serif }
     header{ position:sticky; top:0; background:rgba(17,24,39,.9); backdrop-filter:saturate(150%) blur(6px); border-bottom:1px solid var(--border); z-index:10 }
-    .container{ max-width:1100px; margin:0 auto; padding:16px }
+    .container{ width:min(1400px, calc(100vw - 48px)); margin:0 auto; padding:16px }
     .row{ display:flex; gap:10px; flex-wrap:wrap; align-items:center }
     .pill{ display:inline-flex; gap:8px; align-items:center; padding:6px 10px; border-radius:999px; border:1px solid #334155; background:#0b1220; color:#cbd5e1; font-size:12px }
     .card{ background:var(--card); border:1px solid var(--border); border-radius:14px; padding:12px; margin:16px 0 }


### PR DESCRIPTION
## Summary
- update the admin dashboard container styling to allow up to 1400px width based on viewport size
- ensure the wider container applies to both header and main content areas so tables can use more horizontal space

## Testing
- Manual responsive check in browser (1600px, 768px, 414px viewports)

------
https://chatgpt.com/codex/tasks/task_b_68d0634f7a40833395ee68ac454743bc