### PR TITLE
Normalize reorder answer comparison case-insensitively

### DIFF
--- a/app/static/index.html
+++ b/app/static/index.html
@@ -670,7 +670,9 @@
         const normalizedAns = normalizeEndPunc(normalizeSpaces(currentAnswer()), keepPunc);
         ans = normalizedAns? normalizedAns.charAt(0).toUpperCase()+normalizedAns.slice(1) : normalizedAns;
         const normalizedAnswers = answerList.map(a=>normalizeEndPunc(normalizeSpaces(a), keepPunc));
-        correct = normalizedAnswers.includes(normalizedAns);
+        const normalizedAnsLower = typeof normalizedAns === 'string' ? normalizedAns.toLowerCase() : normalizedAns;
+        const normalizedAnswersLower = normalizedAnswers.map(a=>typeof a === 'string' ? a.toLowerCase() : a);
+        correct = normalizedAnswersLower.includes(normalizedAnsLower);
       } else { // vocab
         ans = normalizeWord(currentAnswer());
         const normalizedAnswers = answerList.map(a=>normalizeWord(a));


### PR DESCRIPTION
## Summary
- normalize both the learner input and accepted answers to the same case before comparison in reorder questions

## Testing
- manual verification of reorder question u4-004 (`she showed me the picture.` accepted)


------
https://chatgpt.com/codex/tasks/task_b_68d8c67b87048333ad6a6bc2a5a3cc24