### PR TITLE
Fix u4-004 distractor text

### DIFF
--- a/app/static/data/questions.json
+++ b/app/static/data/questions.json
@@ -437,7 +437,7 @@
       "wrong": [
         "show",
         "shows",
-        "to"
+        "too"
       ]
     },
     {


### PR DESCRIPTION
## Summary
- replace the u4-004 question distractor "to" with the invalid filler "too" to prevent an alternate correct sentence

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d8d847aac08333b4486d0c4e7c89c9