### PR TITLE
Adjust math page field inputs layout

### DIFF
--- a/app/static/math.html
+++ b/app/static/math.html
@@ -13,8 +13,9 @@
     button:disabled{opacity:.5;cursor:not-allowed;}
     input{width:100%;padding:12px;border-radius:10px;border:1px solid #334155;background:#0b1220;color:#e5e7eb;font-size:16px;}
     .field-stack{display:flex;flex-direction:column;gap:12px;margin-top:16px;}
-    .field-row{display:flex;flex-direction:column;gap:6px;}
+    .field-row{display:flex;flex-direction:row;align-items:center;gap:12px;}
     .field-label{font-size:14px;color:#94a3b8;}
+    .field-row input{width:8ch;flex:0 0 auto;padding:8px 10px;}
     #feedback{margin-top:12px;min-height:2.2em;}
     .muted{color:#94a3b8;}
     .ok{color:#22c55e;}


### PR DESCRIPTION
## Summary
- display math quiz field rows horizontally so labels and inputs stay inline
- scope input width inside field rows to keep compact math entry fields while preserving full-width single-field inputs

## Testing
- Manually reloaded http://127.0.0.1:8000/math.html

------
https://chatgpt.com/codex/tasks/task_b_68d9daa258d88333bf587179b260d8c3