### PR TITLE
Show math explain text for incorrect answers

### DIFF
--- a/app/static/math.html
+++ b/app/static/math.html
@@ -294,9 +294,10 @@
       const isCorrect = answers.some(candidate => matchesAnswer(candidate, userValues, fieldSpecs));
       state.graded = true;
       $('#btn-next').disabled = false;
+      const explain = q && q.explain ? `<div class="muted" style="margin-top:8px">解説: ${q.explain}</div>` : '';
       if(isCorrect){
         $('#feedback').className = 'ok';
-        $('#feedback').innerHTML = `✅ 正解です！`;
+        $('#feedback').innerHTML = `✅ 正解です！${explain}`;
       } else {
         $('#feedback').className = 'ng';
         const formatted = answers
@@ -313,7 +314,7 @@
             return ans;
           })
           .join('<br><span class="muted">または</span> ');
-        $('#feedback').innerHTML = `❌ 不正解。 正解例: ${formatted}`;
+        $('#feedback').innerHTML = `❌ 不正解。 正解例: ${formatted}${explain}`;
       }
     }
 


### PR DESCRIPTION
## Summary
- append the math question explanation to the feedback message
- ensure incorrect answers also display the explain text alongside correct answers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68db14e6e4988333baf8f55a4128285a