### PR TITLE
Update level assignments for English question set

### DIFF
--- a/app/static/data/english/questions.json
+++ b/app/static/data/english/questions.json
@@ -10,757 +10,1224 @@
       "unit": "present-simple",
       "jp": "彼は放課後にサッカーをします。",
       "en": "He plays soccer after school.",
-      "chunks": ["he", "plays", "soccer", "after", "school", "."],
+      "chunks": [
+        "he",
+        "plays",
+        "soccer",
+        "after",
+        "school",
+        "."
+      ],
       "tip": "三単現: He plays（sを忘れずに）",
       "explain": "主語が He などの三人称単数なので、一般動詞 play に s をつけて plays とします。",
       "wrong": [
         "is",
         "does",
         "do"
-      ]
+      ],
+      "level": "Lv1"
     },
     {
       "id": "r002",
       "unit": "present-continuous-q",
       "jp": "あなたは今宿題をしていますか。",
       "en": "Are you doing your homework now?",
-      "chunks": ["are", "you", "doing", "your", "homework", "now", "?"],
+      "chunks": [
+        "are",
+        "you",
+        "doing",
+        "your",
+        "homework",
+        "now",
+        "?"
+      ],
       "tip": "進行形の疑問: Are you ～?",
       "explain": "現在進行形の疑問文なので be 動詞 Are を前に出し、動詞は doing のように -ing 形にします。",
       "wrong": [
         "has",
         "do",
         "did"
-      ]
+      ],
+      "level": "Lv1"
     },
     {
       "id": "r003",
       "unit": "past-simple",
       "jp": "私は昨日その博物館に行きました。",
       "en": "I went to the museum yesterday.",
-      "chunks": ["I", "went", "to", "the", "museum", "yesterday", "."],
+      "chunks": [
+        "I",
+        "went",
+        "to",
+        "the",
+        "museum",
+        "yesterday",
+        "."
+      ],
       "tip": "go の過去形は went",
       "explain": "過去の出来事なので go ではなく過去形の went を使い、yesterday と時を示す語も合わせます。",
       "wrong": [
         "am",
         "is",
         "are"
-      ]
+      ],
+      "level": "Lv1"
     },
     {
       "id": "r004",
       "unit": "comparative",
       "jp": "この本はあの本よりおもしろい。",
       "en": "This book is more interesting than that one.",
-      "chunks": ["this", "book", "is", "more", "interesting", "than", "that", "one", "."],
+      "chunks": [
+        "this",
+        "book",
+        "is",
+        "more",
+        "interesting",
+        "than",
+        "that",
+        "one",
+        "."
+      ],
       "tip": "比較級: more … than ～",
       "explain": "比較級では more + 形容詞 + than ～ の語順を取り、than の後ろに比較対象を置きます。",
       "wrong": [
         "do",
         "did",
         "does"
-      ]
+      ],
+      "level": "Lv1"
     },
     {
       "id": "r005",
       "unit": "there-is",
       "jp": "机の下に猫が一匹います。",
       "en": "There is a cat under the desk.",
-      "chunks": ["there", "is", "a", "cat", "under", "the", "desk", "."],
+      "chunks": [
+        "there",
+        "is",
+        "a",
+        "cat",
+        "under",
+        "the",
+        "desk",
+        "."
+      ],
       "tip": "存在文: There is/are",
       "explain": "存在を表す文では there is/are で始め、単数名詞 a cat に合わせて is を使います。",
       "wrong": [
         "does",
         "is",
         "do"
-      ]
+      ],
+      "level": "Lv1"
     },
     {
       "id": "r006",
       "unit": "present-3sg",
       "jp": "彼女は毎朝朝ごはんを食べます。",
       "en": "She has breakfast every morning.",
-      "chunks": ["she", "has", "breakfast", "every", "morning", "."],
+      "chunks": [
+        "she",
+        "has",
+        "breakfast",
+        "every",
+        "morning",
+        "."
+      ],
       "tip": "have → has（3単現）",
       "explain": "主語が She の三人称単数なので、動詞 have は has に変化させて現在形を作ります。",
       "wrong": [
         "are",
         "am",
         "is"
-      ]
+      ],
+      "level": "Lv1"
     },
     {
       "id": "r007",
       "unit": "present-continuous",
       "jp": "私は英語を勉強しているところです。",
       "en": "I am studying English.",
-      "chunks": ["I", "am", "studying", "English", "."],
+      "chunks": [
+        "I",
+        "am",
+        "studying",
+        "English",
+        "."
+      ],
       "tip": "be + -ing で進行形",
       "explain": "現在進行形は be 動詞 + 動詞の -ing 形で表し、主語 I に合わせて am studying とします。",
       "wrong": [
         "does",
         "do",
         "did"
-      ]
+      ],
+      "level": "Lv1"
     },
     {
       "id": "r008",
       "unit": "past-simple-q",
       "jp": "あなたは昨日映画を見ましたか。",
       "en": "Did you watch a movie yesterday?",
-      "chunks": ["did", "you", "watch", "a", "movie", "yesterday", "?"],
+      "chunks": [
+        "did",
+        "you",
+        "watch",
+        "a",
+        "movie",
+        "yesterday",
+        "?"
+      ],
       "tip": "過去の疑問: Did + 主語 + 動詞原形",
       "explain": "過去の疑問文は Did + 主語 + 動詞原形 の形になるので、watch は原形のまま使います。",
       "wrong": [
         "is",
         "are",
         "am"
-      ]
+      ],
+      "level": "Lv1"
     },
     {
       "id": "r009",
       "unit": "present-simple",
       "jp": "私は毎日朝ごはんを食べます。",
       "en": "I eat breakfast every day.",
-      "chunks": ["I", "eat", "breakfast", "every", "day", "."],
+      "chunks": [
+        "I",
+        "eat",
+        "breakfast",
+        "every",
+        "day",
+        "."
+      ],
       "tip": "一般動詞の現在形: 主語 + 動詞原形",
       "explain": "主語が I のときは動詞を原形で用い、頻度を表す every day を文末に置きます。",
       "wrong": [
         "is",
         "do",
         "does"
-      ]
+      ],
+      "level": "Lv1"
     },
     {
       "id": "r010",
       "unit": "present-simple-q",
       "jp": "あなたはサッカーが好きですか。",
       "en": "Do you like soccer?",
-      "chunks": ["do", "you", "like", "soccer", "?"],
+      "chunks": [
+        "do",
+        "you",
+        "like",
+        "soccer",
+        "?"
+      ],
       "tip": "一般動詞の疑問文: Do + 主語 + 動詞原形",
       "explain": "一般動詞の疑問文では Do/Does を前に置き、動詞 like は原形のままにします。",
       "wrong": [
         "am",
         "is",
         "are"
-      ]
+      ],
+      "level": "Lv1"
     },
     {
       "id": "r011",
       "unit": "be-verb",
       "jp": "彼女は生徒です。",
       "en": "She is a student.",
-      "chunks": ["she", "is", "a", "student", "."],
+      "chunks": [
+        "she",
+        "is",
+        "a",
+        "student",
+        "."
+      ],
       "tip": "be動詞の肯定文: 主語 + be動詞 + 補語",
       "explain": "be 動詞の文では主語 She に合わせて is を用い、補語の名詞 a student を続けます。",
       "wrong": [
         "do",
         "does",
         "did"
-      ]
+      ],
+      "level": "Lv1"
     },
     {
       "id": "r012",
       "unit": "be-verb-neg",
       "jp": "私は先生ではありません。",
       "en": "I am not a teacher.",
-      "chunks": ["I", "am", "not", "a", "teacher", "."],
+      "chunks": [
+        "I",
+        "am",
+        "not",
+        "a",
+        "teacher",
+        "."
+      ],
       "tip": "be動詞の否定文: 主語 + be動詞 + not + 補語",
       "explain": "否定文は be 動詞の後ろに not を入れ、主語 I に合わせて am not を使います。",
       "wrong": [
         "does",
         "do",
         "is"
-      ]
+      ],
+      "level": "Lv1"
     },
     {
       "id": "r013",
       "unit": "be-verb-q",
       "jp": "彼はアメリカ出身ですか。",
       "en": "Is he from America?",
-      "chunks": ["is", "he", "from", "America", "?"],
+      "chunks": [
+        "is",
+        "he",
+        "from",
+        "America",
+        "?"
+      ],
       "tip": "be動詞の疑問文: Be動詞 + 主語 + 補語",
       "explain": "be 動詞の疑問文は Is/Are を文頭に出し、Is he ～? の語順にします。",
       "wrong": [
         "do",
         "does",
         "did"
-      ]
+      ],
+      "level": "Lv1"
     },
     {
       "id": "r014",
       "unit": "present-cont-q",
       "jp": "彼らはいまサッカーをしていますか。",
       "en": "Are they playing soccer now?",
-      "chunks": ["are", "they", "playing", "soccer", "now", "?"],
+      "chunks": [
+        "are",
+        "they",
+        "playing",
+        "soccer",
+        "now",
+        "?"
+      ],
       "tip": "現在進行形の疑問文: Be動詞 + 主語 + 動詞ing",
       "explain": "複数主語 they なので be 動詞は Are を使い、play は進行形の playing にします。",
       "wrong": [
         "has",
         "have",
         "is"
-      ]
+      ],
+      "level": "Lv1"
     },
     {
       "id": "r015",
       "unit": "present-cont-neg",
       "jp": "彼はテレビを見ていません。",
       "en": "He is not watching TV.",
-      "chunks": ["he", "is", "not", "watching", "TV", "."],
+      "chunks": [
+        "he",
+        "is",
+        "not",
+        "watching",
+        "TV",
+        "."
+      ],
       "tip": "現在進行形の否定文: 主語 + be動詞 + not + 動詞ing",
       "explain": "現在進行形の否定は be 動詞のあとに not を入れ、watch の -ing 形 watching を続けます。",
       "wrong": [
         "do",
         "did",
         "does"
-      ]
+      ],
+      "level": "Lv1"
     },
     {
       "id": "r016",
       "unit": "present-simple-q",
       "jp": "あなたのお父さんは日曜日にテニスをしますか。",
       "en": "Does your father play tennis on Sunday?",
-      "chunks": ["does", "your", "father", "play", "tennis", "on", "Sunday", "?"],
+      "chunks": [
+        "does",
+        "your",
+        "father",
+        "play",
+        "tennis",
+        "on",
+        "Sunday",
+        "?"
+      ],
       "tip": "三単現の疑問文: Does + 主語 + 動詞原形",
       "explain": "主語が your father のような三人称単数なので疑問文では Does を使い、動詞 play は原形に戻します。",
       "wrong": [
         "am",
         "is",
         "are"
-      ]
+      ],
+      "level": "Lv1"
     },
     {
       "id": "r017",
       "unit": "present-simple-neg",
       "jp": "私は図書館で勉強しません。",
       "en": "I do not study in the library.",
-      "chunks": ["I", "do", "not", "study", "in", "the", "library", "."],
+      "chunks": [
+        "I",
+        "do",
+        "not",
+        "study",
+        "in",
+        "the",
+        "library",
+        "."
+      ],
       "tip": "一般動詞の否定文: do not + 動詞原形",
       "explain": "一般動詞の否定文では do not / does not + 動詞原形 の形を取り、主語 I には do not を使います。",
       "wrong": [
         "is",
         "are",
         "am"
-      ]
+      ],
+      "level": "Lv1"
     },
     {
       "id": "r018",
       "unit": "be-verb-q",
       "jp": "これらの本はあなたのですか。",
       "en": "Are these books yours?",
-      "chunks": ["are", "these", "books", "yours", "?"],
+      "chunks": [
+        "are",
+        "these",
+        "books",
+        "yours",
+        "?"
+      ],
       "tip": "be動詞の疑問文（複数）: Are + 複数主語",
       "explain": "複数名詞 these books に合わせて be 動詞は Are を使い、Are these books yours? の語順にします。",
       "wrong": [
         "does",
         "do",
         "did"
-      ]
+      ],
+      "level": "Lv1"
     },
     {
       "id": "r019",
       "unit": "present-cont-q",
       "jp": "あなたのお姉さんはいまピアノを弾いていますか。",
       "en": "Is your sister playing the piano now?",
-      "chunks": ["is", "your", "sister", "playing", "the", "piano", "now", "?"],
+      "chunks": [
+        "is",
+        "your",
+        "sister",
+        "playing",
+        "the",
+        "piano",
+        "now",
+        "?"
+      ],
       "tip": "現在進行形の疑問文: Be動詞 + 主語 + 動詞ing",
       "explain": "主語が your sister（単数）なので be 動詞は Is、動詞は進行形の playing を用います。",
       "wrong": [
         "do",
         "does",
         "did"
-      ]
+      ],
+      "level": "Lv1"
     },
     {
       "id": "r020",
       "unit": "there-are",
       "jp": "机の上に3本のえんぴつがあります。",
       "en": "There are three pencils on the desk.",
-      "chunks": ["there", "are", "three", "pencils", "on", "the", "desk", "."],
+      "chunks": [
+        "there",
+        "are",
+        "three",
+        "pencils",
+        "on",
+        "the",
+        "desk",
+        "."
+      ],
       "tip": "存在文（複数）: There are + 複数名詞",
       "explain": "複数名詞 three pencils に合わせて there are で始め、場所を表す前置詞句 on the desk を続けます。",
       "wrong": [
         "does",
         "is",
         "do"
-      ]
+      ],
+      "level": "Lv1"
     },
     {
       "id": "r021",
       "unit": "can-ability",
       "jp": "私は上手にサッカーをすることができます。",
       "en": "I can play soccer well.",
-      "chunks": ["I", "can", "play", "soccer", "well", "."],
+      "chunks": [
+        "I",
+        "can",
+        "play",
+        "soccer",
+        "well",
+        "."
+      ],
       "tip": "can + 動詞原形で「〜できる」を表す",
       "explain": "能力を表すときは can + 動詞原形 を使い、play の後ろに副詞 well を置いて「上手に」を表現します。",
       "wrong": [
         "does",
         "is",
         "are"
-      ]
+      ],
+      "level": "Lv1"
     },
     {
       "id": "r022",
       "unit": "be-verb-q",
       "jp": "あなたは美術部に興味を持っていますか。",
       "en": "Are you interested in the art club?",
-      "chunks": ["are", "you", "interested", "in", "the", "art", "club", "?"],
+      "chunks": [
+        "are",
+        "you",
+        "interested",
+        "in",
+        "the",
+        "art",
+        "club",
+        "?"
+      ],
       "tip": "be動詞 + interested in ～? で「～に興味がありますか」を表す",
       "explain": "興味があるかを尋ねる疑問文では be 動詞 Are を文頭に置き、形容詞 interested の後ろに前置詞 in と目的語 the art club を続けます。",
       "wrong": [
         "do",
         "does",
         "did"
-      ]
+      ],
+      "level": "Lv1"
     },
     {
       "id": "u3-001",
       "unit": "be-going-to",
       "jp": "私は来週京都を訪れるつもりです。",
       "en": "I am going to visit Kyoto next week.",
-      "chunks": ["I", "am", "going to", "visit", "Kyoto", "next week", "."],
+      "chunks": [
+        "I",
+        "am",
+        "going to",
+        "visit",
+        "Kyoto",
+        "next week",
+        "."
+      ],
       "tip": "be going to + 動詞原形",
       "explain": "be going to の形で「～するつもり」を表し、動詞 visit は原形のまま使います。",
       "wrong": [
         "will",
         "do",
         "does"
-      ]
+      ],
+      "level": "Lv1"
     },
     {
       "id": "u3-002",
       "unit": "will",
       "jp": "彼は明日その本を読むでしょう。",
       "en": "He will read the book tomorrow.",
-      "chunks": ["he", "will", "read", "the book", "tomorrow", "."],
+      "chunks": [
+        "he",
+        "will",
+        "read",
+        "the book",
+        "tomorrow",
+        "."
+      ],
       "tip": "未来: will + 動詞原形",
       "explain": "未来の出来事には will + 動詞原形 を使い、read は原形のままにします。",
       "wrong": [
         "is",
         "does",
         "did"
-      ]
+      ],
+      "level": "Lv1"
     },
     {
       "id": "u3-003",
       "unit": "be-going-to-q",
       "jp": "あなたは今夜テレビを見るつもりですか。",
       "en": "Are you going to watch TV tonight?",
-      "chunks": ["are", "you", "going to", "watch", "TV", "tonight", "?"],
+      "chunks": [
+        "are",
+        "you",
+        "going to",
+        "watch",
+        "TV",
+        "tonight",
+        "?"
+      ],
       "tip": "疑問文: Are you going to + 動詞原形?",
       "explain": "be going to の疑問文は Are/Is を前に出し、watch は原形で続けます。",
       "wrong": [
         "do",
         "will",
         "is"
-      ]
+      ],
+      "level": "Lv1"
     },
     {
       "id": "u3-004",
       "unit": "will-neg",
       "jp": "私はそのゲームをしないでしょう。",
       "en": "I will not play the game.",
-      "chunks": ["I", "will not", "play", "the game", "."],
+      "chunks": [
+        "I",
+        "will not",
+        "play",
+        "the game",
+        "."
+      ],
       "tip": "否定文: will not + 動詞原形",
       "explain": "will の否定は will not / won't + 動詞原形 の形で、play を原形のまま用います。",
       "wrong": [
         "do",
         "am",
         "does"
-      ]
+      ],
+      "level": "Lv1"
     },
     {
       "id": "u3-005",
       "unit": "be-going-to-neg",
       "jp": "私は明日その映画を見ないつもりです。",
       "en": "I am not going to watch the movie tomorrow.",
-      "chunks": ["I", "am not", "going to", "watch", "the movie", "tomorrow", "."],
+      "chunks": [
+        "I",
+        "am not",
+        "going to",
+        "watch",
+        "the movie",
+        "tomorrow",
+        "."
+      ],
       "tip": "否定文: am not going to + 動詞原形",
       "explain": "be going to の否定は be 動詞のあとに not を入れ、watch は原形で続けます。",
       "wrong": [
         "will",
         "do",
         "is"
-      ]
+      ],
+      "level": "Lv1"
     },
     {
       "id": "u3-006",
       "unit": "will-q",
       "jp": "彼は来週テニスをするでしょうか。",
       "en": "Will he play tennis next week?",
-      "chunks": ["will", "he", "play", "tennis", "next week", "?"],
+      "chunks": [
+        "will",
+        "he",
+        "play",
+        "tennis",
+        "next week",
+        "?"
+      ],
       "tip": "疑問文: Will + 主語 + 動詞原形?",
       "explain": "will の疑問文は Will を文頭に置き、play は原形のままにします。",
       "wrong": [
         "does",
         "is",
         "do"
-      ]
+      ],
+      "level": "Lv1"
     },
     {
       "id": "u3-007",
       "unit": "be-going-to-neg-q",
       "jp": "あなたはその本を読まないつもりですか。",
       "en": "Aren't you going to read the book?",
-      "chunks": ["aren't", "you", "going to", "read", "the book", "?"],
+      "chunks": [
+        "aren't",
+        "you",
+        "going to",
+        "read",
+        "the book",
+        "?"
+      ],
       "tip": "否定疑問文: Aren't you going to ～?",
       "explain": "be going to の否定疑問では Aren't you ～? の形をとり、read は原形で用います。",
       "wrong": [
         "will",
         "do",
         "is"
-      ]
+      ],
+      "level": "Lv1"
     },
     {
       "id": "u4-001",
       "unit": "there-is",
       "jp": "机の上に1冊の本があります。",
       "en": "There is a book on the desk.",
-      "chunks": ["there is", "a book", "on the desk", "."],
+      "chunks": [
+        "there is",
+        "a book",
+        "on the desk",
+        "."
+      ],
       "tip": "存在文: There is + 単数名詞",
       "explain": "単数名詞 a book を紹介する存在文なので there is を使い、場所 on the desk を後ろに置きます。",
       "wrong": [
         "are",
         "has",
         "do"
-      ]
+      ],
+      "level": "Lv1"
     },
     {
       "id": "u4-002",
       "unit": "there-are",
       "jp": "この教室には20人の生徒がいます。",
       "en": "There are twenty students in this classroom.",
-      "chunks": ["there are", "twenty students", "in this classroom", "."],
+      "chunks": [
+        "there are",
+        "twenty students",
+        "in this classroom",
+        "."
+      ],
       "tip": "存在文: There are + 複数名詞",
       "explain": "複数名詞 twenty students に合わせて there are を使い、場所 in this classroom を続けます。",
       "wrong": [
         "is",
         "has",
         "do"
-      ]
+      ],
+      "level": "Lv1"
     },
     {
       "id": "u4-003",
       "unit": "svoo",
       "jp": "私は彼に本を与えました。",
       "en": "I gave him a book.",
-      "accept": ["I gave a book to him."],
-      "chunks": ["I", "gave", "him", "a book", "."],
+      "accept": [
+        "I gave a book to him."
+      ],
+      "chunks": [
+        "I",
+        "gave",
+        "him",
+        "a book",
+        "."
+      ],
       "tip": "SVOO: give + 人 + 物",
       "explain": "SVOO では give + 人 + 物 の語順を取り、過去形 gave で表します。",
       "wrong": [
         "give",
         "gives",
         "to"
-      ]
+      ],
+      "level": "Lv1"
     },
     {
       "id": "u4-004",
       "unit": "svoo",
       "jp": "彼女は私にその写真を見せました。",
       "en": "She showed me the picture.",
-      "chunks": ["she", "showed", "me", "the picture", "."],
+      "chunks": [
+        "she",
+        "showed",
+        "me",
+        "the picture",
+        "."
+      ],
       "tip": "SVOO: show + 人 + 物",
       "explain": "show の過去形 showed を使い、人 me を先に置いてから物 the picture を続けます。",
       "wrong": [
         "show",
         "shows",
         "too"
-      ]
+      ],
+      "level": "Lv1"
     },
     {
       "id": "u4-005",
       "unit": "svoo",
       "jp": "私は彼にその話を伝えました。",
       "en": "I told him the story.",
-      "chunks": ["I", "told", "him", "the story", "."],
+      "chunks": [
+        "I",
+        "told",
+        "him",
+        "the story",
+        "."
+      ],
       "tip": "SVOO: tell + 人 + 物",
       "explain": "tell の過去形 told を使い、目的語は人 him → 物 the story の順で並べます。",
       "wrong": [
         "tell",
         "tells",
         "to"
-      ]
+      ],
+      "level": "Lv1"
     },
     {
       "id": "u4-006",
       "unit": "svoo",
       "jp": "彼は私に自転車を貸しました。",
       "en": "He lent me his bicycle.",
-      "chunks": ["he", "lent", "me", "his bicycle", "."],
+      "chunks": [
+        "he",
+        "lent",
+        "me",
+        "his bicycle",
+        "."
+      ],
       "tip": "SVOO: lend + 人 + 物",
       "explain": "「lend」の過去形は「lent」です。過去の出来事なので動詞も過去形にします。",
       "wrong": [
         "lend",
         "lends",
         "to"
-      ]
+      ],
+      "level": "Lv1"
     },
     {
       "id": "u4-007",
       "unit": "there-is-neg",
       "jp": "机の上にペンはありません。",
       "en": "There is not a pen on the desk.",
-      "chunks": ["there is not", "a pen", "on the desk", "."],
+      "chunks": [
+        "there is not",
+        "a pen",
+        "on the desk",
+        "."
+      ],
       "tip": "存在文の否定: There is not + 単数名詞",
       "wrong": [
         "are",
         "has",
         "do"
       ],
-      "explain": "否定の存在文では there is not + 名詞 で「～がない」を表します。"
+      "explain": "否定の存在文では there is not + 名詞 で「～がない」を表します。",
+      "level": "Lv1"
     },
     {
       "id": "u4-008",
       "unit": "there-are-q",
       "jp": "この部屋に椅子はいくつありますか。",
       "en": "How many chairs are there in this room?",
-      "chunks": ["how many chairs", "are there", "in this room", "?"],
+      "chunks": [
+        "how many chairs",
+        "are there",
+        "in this room",
+        "?"
+      ],
       "tip": "疑問文: How many + 複数名詞 + are there ～?",
       "wrong": [
         "is",
         "has",
         "do"
       ],
-      "explain": "個数を尋ねる疑問文は How many + 名詞 + are there...? の語順を取ります。"
+      "explain": "個数を尋ねる疑問文は How many + 名詞 + are there...? の語順を取ります。",
+      "level": "Lv1"
     },
     {
       "id": "u4-009",
       "unit": "svoo-neg",
       "jp": "私は彼に手紙を渡しませんでした。",
       "en": "I did not give him a letter.",
-      "chunks": ["I", "did not", "give", "him", "a letter", "."],
+      "chunks": [
+        "I",
+        "did not",
+        "give",
+        "him",
+        "a letter",
+        "."
+      ],
       "tip": "SVOOの否定: did not + 動詞原形",
       "wrong": [
         "do",
         "does",
         "is"
       ],
-      "explain": "過去の否定文では did not + 動詞原形 を用い、give を原形のまま残します。"
+      "explain": "過去の否定文では did not + 動詞原形 を用い、give を原形のまま残します。",
+      "level": "Lv1"
     },
     {
       "id": "u4-010",
       "unit": "svoo-q",
       "jp": "彼はあなたにその話をしましたか。",
       "en": "Did he tell you the story?",
-      "chunks": ["did", "he", "tell", "you", "the story", "?"],
+      "chunks": [
+        "did",
+        "he",
+        "tell",
+        "you",
+        "the story",
+        "?"
+      ],
       "tip": "SVOOの疑問文: Did + 主語 + 動詞原形 + 人 + 物?",
       "wrong": [
         "does",
         "is",
         "do"
       ],
-      "explain": "過去の疑問文は Did + 主語 + 動詞原形 の形になるので、tell を原形で使います。"
+      "explain": "過去の疑問文は Did + 主語 + 動詞原形 の形になるので、tell を原形で使います。",
+      "level": "Lv1"
     },
     {
       "id": "cj-and-001",
       "unit": "conjunction-and",
       "jp": "私はリンゴとオレンジが好きです。",
       "en": "I like apples and oranges.",
-      "chunks": ["I", "like", "apples", "and", "oranges", "."],
+      "chunks": [
+        "I",
+        "like",
+        "apples",
+        "and",
+        "oranges",
+        "."
+      ],
       "tip": "and で「AとB」をつなぐ",
       "wrong": [
         "but",
         "so",
         "because"
       ],
-      "explain": "同じ主語 I が好きなもの apples と oranges を and で並べ、「～と～が好きです」と表します。"
+      "explain": "同じ主語 I が好きなもの apples と oranges を and で並べ、「～と～が好きです」と表します。",
+      "level": "Lv1"
     },
     {
       "id": "cj-and-002",
       "unit": "conjunction-and",
       "jp": "彼は牛乳とパンを買いました。",
       "en": "He bought milk and bread.",
-      "chunks": ["He", "bought", "milk", "and", "bread", "."],
+      "chunks": [
+        "He",
+        "bought",
+        "milk",
+        "and",
+        "bread",
+        "."
+      ],
       "tip": "名詞と名詞を and で並べる",
       "wrong": [
         "but",
         "because",
         "if"
       ],
-      "explain": "買ったもの milk と bread を and でつなぎ、2つの名詞を並列しています。"
+      "explain": "買ったもの milk と bread を and でつなぎ、2つの名詞を並列しています。",
+      "level": "Lv1"
     },
     {
       "id": "cj-and-003",
       "unit": "conjunction-and",
       "jp": "彼らはペンとノートを持っています。",
       "en": "They have a pen and a notebook.",
-      "chunks": ["They", "have", "a", "pen", "and", "a", "notebook", "."],
+      "chunks": [
+        "They",
+        "have",
+        "a",
+        "pen",
+        "and",
+        "a",
+        "notebook",
+        "."
+      ],
       "tip": "持ち物も and でまとめられる",
       "wrong": [
         "but",
         "so",
         "although"
       ],
-      "explain": "have の目的語 a pen と a notebook を and で結び、2つの持ち物を並べています。"
+      "explain": "have の目的語 a pen と a notebook を and で結び、2つの持ち物を並べています。",
+      "level": "Lv1"
     },
     {
       "id": "cj-but-001",
       "unit": "conjunction-but",
       "jp": "私は外で遊びたかったが雨が降りました。",
       "en": "I wanted to play outside, but it rained.",
-      "chunks": ["I", "wanted", "to", "play", "outside", ",", "but", "it", "rained", "."],
+      "chunks": [
+        "I",
+        "wanted",
+        "to",
+        "play",
+        "outside",
+        ",",
+        "but",
+        "it",
+        "rained",
+        "."
+      ],
       "tip": "but で前後の内容を対比する",
       "wrong": [
         "and",
         "so",
         "because"
       ],
-      "explain": "希望 wanted to play outside と結果 it rained を but で対比し、「しかし」を表現します。"
+      "explain": "希望 wanted to play outside と結果 it rained を but で対比し、「しかし」を表現します。",
+      "level": "Lv1"
     },
     {
       "id": "cj-but-002",
       "unit": "conjunction-but",
       "jp": "彼は小さいですが強いです。",
       "en": "He is small but strong.",
-      "chunks": ["He", "is", "small", "but", "strong", "."],
+      "chunks": [
+        "He",
+        "is",
+        "small",
+        "but",
+        "strong",
+        "."
+      ],
       "tip": "but は性質の対比にも使える",
       "wrong": [
         "and",
         "so",
         "while"
       ],
-      "explain": "同じ主語 He の2つの性質 small と strong を but でつなぎ対比を示します。"
+      "explain": "同じ主語 He の2つの性質 small と strong を but でつなぎ対比を示します。",
+      "level": "Lv1"
     },
     {
       "id": "cj-but-003",
       "unit": "conjunction-but",
       "jp": "彼女は速く走りましたがバスに乗り遅れました。",
       "en": "She ran fast but missed the bus.",
-      "chunks": ["She", "ran", "fast", "but", "missed", "the", "bus", "."],
+      "chunks": [
+        "She",
+        "ran",
+        "fast",
+        "but",
+        "missed",
+        "the",
+        "bus",
+        "."
+      ],
       "tip": "but で努力と結果のギャップを示す",
       "wrong": [
         "and",
         "because",
         "if"
       ],
-      "explain": "行動 ran fast と結果 missed the bus を but で逆接につなぎます。"
+      "explain": "行動 ran fast と結果 missed the bus を but で逆接につなぎます。",
+      "level": "Lv1"
     },
     {
       "id": "cj-because-001",
       "unit": "conjunction-because",
       "jp": "私は病気だったので家にいました。",
       "en": "I stayed home because I was sick.",
-      "chunks": ["I", "stayed", "home", "because", "I", "was", "sick", "."],
+      "chunks": [
+        "I",
+        "stayed",
+        "home",
+        "because",
+        "I",
+        "was",
+        "sick",
+        "."
+      ],
       "tip": "because で理由を説明する",
       "wrong": [
         "so",
         "but",
         "although"
       ],
-      "explain": "行動 stayed home とその理由 I was sick を because で結びます。"
+      "explain": "行動 stayed home とその理由 I was sick を because で結びます。",
+      "level": "Lv2"
     },
     {
       "id": "cj-because-002",
       "unit": "conjunction-because",
       "jp": "彼は賞をもらったのでうれしいです。",
       "en": "He is happy because he won a prize.",
-      "chunks": ["He", "is", "happy", "because", "he", "won", "a", "prize", "."],
+      "chunks": [
+        "He",
+        "is",
+        "happy",
+        "because",
+        "he",
+        "won",
+        "a",
+        "prize",
+        "."
+      ],
       "tip": "感情の理由も because で表せる",
       "wrong": [
         "so",
         "but",
         "if"
       ],
-      "explain": "気持ち happy の理由となる出来事 he won a prize を because で導き、原因と結果の関係を示します。"
+      "explain": "気持ち happy の理由となる出来事 he won a prize を because で導き、原因と結果の関係を示します。",
+      "level": "Lv2"
     },
     {
       "id": "cj-because-003",
       "unit": "conjunction-because",
       "jp": "私たちは寒かったので上着を着ました。",
       "en": "We wore coats because it was cold.",
-      "chunks": ["We", "wore", "coats", "because", "it", "was", "cold", "."],
+      "chunks": [
+        "We",
+        "wore",
+        "coats",
+        "because",
+        "it",
+        "was",
+        "cold",
+        "."
+      ],
       "tip": "because 節は文末に置くことが多い",
       "wrong": [
         "so",
         "but",
         "unless"
       ],
-      "explain": "行動 wore coats と理由 it was cold を because で結び、因果関係を示します。"
+      "explain": "行動 wore coats と理由 it was cold を because で結び、因果関係を示します。",
+      "level": "Lv2"
     },
     {
       "id": "cj-so-001",
       "unit": "conjunction-so",
       "jp": "私はおなかがすいていたので昼ごはんを食べました。",
       "en": "I was hungry, so I ate lunch.",
-      "chunks": ["I", "was", "hungry", ",", "so", "I", "ate", "lunch", "."],
+      "chunks": [
+        "I",
+        "was",
+        "hungry",
+        ",",
+        "so",
+        "I",
+        "ate",
+        "lunch",
+        "."
+      ],
       "tip": "so で原因から結果を導く",
       "wrong": [
         "because",
         "but",
         "and"
       ],
-      "explain": "状態 was hungry が原因で、結果 ate lunch を so でつなぎます。"
+      "explain": "状態 was hungry が原因で、結果 ate lunch を so でつなぎます。",
+      "level": "Lv2"
     },
     {
       "id": "cj-so-002",
       "unit": "conjunction-so",
       "jp": "遅かったので私たちは家に帰りました。",
       "en": "It was late, so we went home.",
-      "chunks": ["It", "was", "late", ",", "so", "we", "went", "home", "."],
+      "chunks": [
+        "It",
+        "was",
+        "late",
+        ",",
+        "so",
+        "we",
+        "went",
+        "home",
+        "."
+      ],
       "tip": "so は「だから、結果として」を表す",
       "wrong": [
         "because",
         "but",
         "if"
       ],
-      "explain": "原因 was late と結果 went home を so で結び、「だから～した」を表します。"
+      "explain": "原因 was late と結果 went home を so で結び、「だから～した」を表します。",
+      "level": "Lv2"
     },
     {
       "id": "cj-so-003",
       "unit": "conjunction-so",
       "jp": "彼女はよく勉強したのでテストに合格しました。",
       "en": "She studied hard, so she passed the test.",
-      "chunks": ["She", "studied", "hard", ",", "so", "she", "passed", "the", "test", "."],
+      "chunks": [
+        "She",
+        "studied",
+        "hard",
+        ",",
+        "so",
+        "she",
+        "passed",
+        "the",
+        "test",
+        "."
+      ],
       "tip": "努力と結果を so でつなげる",
       "wrong": [
         "because",
         "but",
         "although"
       ],
-      "explain": "努力を表す主節 She studied hard と結果 she passed the test を so で結びます。"
+      "explain": "努力を表す主節 She studied hard と結果 she passed the test を so で結びます。",
+      "level": "Lv2"
     },
     {
       "id": "cj-when-001",
       "unit": "conjunction-when",
       "jp": "私は雨が降るとき本を読みます。",
       "en": "I read books when it rains.",
-      "chunks": ["I", "read", "books", "when", "it", "rains", "."],
+      "chunks": [
+        "I",
+        "read",
+        "books",
+        "when",
+        "it",
+        "rains",
+        "."
+      ],
       "tip": "when で「～するとき」を表す",
       "wrong": [
         "if",
         "because",
         "so"
       ],
-      "explain": "習慣を表す主節 I read books に、条件となる when it rains を続けます。"
+      "explain": "習慣を表す主節 I read books に、条件となる when it rains を続けます。",
+      "level": "Lv2"
     },
     {
       "id": "cj-when-002",
       "unit": "conjunction-when",
       "jp": "彼女は家に着いたとき私に電話します。",
       "en": "She calls me when she gets home.",
-      "chunks": ["She", "calls", "me", "when", "she", "gets", "home", "."],
+      "chunks": [
+        "She",
+        "calls",
+        "me",
+        "when",
+        "she",
+        "gets",
+        "home",
+        "."
+      ],
       "tip": "主節の後ろに when 節を置く",
       "wrong": [
         "if",
         "because",
         "after"
       ],
-      "explain": "主節 She calls me のタイミングを when she gets home で示します。"
+      "explain": "主節 She calls me のタイミングを when she gets home で示します。",
+      "level": "Lv2"
     },
     {
       "id": "cj-when-003",
       "unit": "conjunction-when",
       "jp": "私たちは食べるとき手を洗います。",
       "en": "We wash our hands when we eat.",
-      "chunks": ["We", "wash", "our", "hands", "when", "we", "eat", "."],
+      "chunks": [
+        "We",
+        "wash",
+        "our",
+        "hands",
+        "when",
+        "we",
+        "eat",
+        "."
+      ],
       "tip": "when 節は文末に置くと読みやすい",
       "wrong": [
         "if",
         "because",
         "while"
       ],
-      "explain": "習慣 wash our hands とそのタイミング when we eat を when で結んでいます。"
+      "explain": "習慣 wash our hands とそのタイミング when we eat を when で結んでいます。",
+      "level": "Lv2"
     }
   ],
   "vocab": [
@@ -770,7 +1237,8 @@
       "jp": "会う",
       "en": "meet",
       "pos": "verb",
-      "tip": ""
+      "tip": "",
+      "level": "Lv1"
     },
     {
       "id": "v002",
@@ -778,7 +1246,8 @@
       "jp": "忘れる",
       "en": "forget",
       "pos": "verb",
-      "tip": ""
+      "tip": "",
+      "level": "Lv1"
     },
     {
       "id": "v003",
@@ -786,7 +1255,8 @@
       "jp": "怖い",
       "en": "scary",
       "pos": "adjective",
-      "tip": ""
+      "tip": "",
+      "level": "Lv1"
     },
     {
       "id": "v004",
@@ -794,7 +1264,8 @@
       "jp": "他の",
       "en": "other",
       "pos": "adjective",
-      "tip": ""
+      "tip": "",
+      "level": "Lv1"
     },
     {
       "id": "v005",
@@ -802,7 +1273,8 @@
       "jp": "探す（探している最中）",
       "en": "look for",
       "pos": "verb",
-      "tip": ""
+      "tip": "",
+      "level": "Lv1"
     },
     {
       "id": "v006",
@@ -810,7 +1282,8 @@
       "jp": "感じる",
       "en": "feel",
       "pos": "verb",
-      "tip": ""
+      "tip": "",
+      "level": "Lv1"
     },
     {
       "id": "v007",
@@ -818,7 +1291,8 @@
       "jp": "尋ねる",
       "en": "ask",
       "pos": "verb",
-      "tip": ""
+      "tip": "",
+      "level": "Lv1"
     },
     {
       "id": "v008",
@@ -826,7 +1300,8 @@
       "jp": "わくわくする",
       "en": "excited",
       "pos": "adjective",
-      "tip": ""
+      "tip": "",
+      "level": "Lv1"
     },
     {
       "id": "v009",
@@ -834,7 +1309,8 @@
       "jp": "大切な",
       "en": "important",
       "pos": "adjective",
-      "tip": ""
+      "tip": "",
+      "level": "Lv1"
     },
     {
       "id": "v010",
@@ -842,7 +1318,8 @@
       "jp": "周りに",
       "en": "around",
       "pos": "preposition",
-      "tip": ""
+      "tip": "",
+      "level": "Lv1"
     },
     {
       "id": "v011",
@@ -850,7 +1327,8 @@
       "jp": "同じ",
       "en": "same",
       "pos": "adjective",
-      "tip": ""
+      "tip": "",
+      "level": "Lv1"
     },
     {
       "id": "v012",
@@ -858,7 +1336,8 @@
       "jp": "決して～ない",
       "en": "never",
       "pos": "adverb",
-      "tip": ""
+      "tip": "",
+      "level": "Lv1"
     },
     {
       "id": "v013",
@@ -866,7 +1345,8 @@
       "jp": "もちろん",
       "en": "sure",
       "pos": "adjective",
-      "tip": ""
+      "tip": "",
+      "level": "Lv1"
     },
     {
       "id": "v014",
@@ -874,7 +1354,8 @@
       "jp": "両方",
       "en": "both",
       "pos": "pronoun",
-      "tip": ""
+      "tip": "",
+      "level": "Lv1"
     },
     {
       "id": "v015",
@@ -882,7 +1363,8 @@
       "jp": "離れて",
       "en": "away",
       "pos": "adverb",
-      "tip": ""
+      "tip": "",
+      "level": "Lv1"
     },
     {
       "id": "v016",
@@ -890,7 +1372,8 @@
       "jp": "出発する",
       "en": "leave",
       "pos": "verb",
-      "tip": ""
+      "tip": "",
+      "level": "Lv1"
     },
     {
       "id": "v017",
@@ -898,7 +1381,8 @@
       "jp": "思い出す",
       "en": "remember",
       "pos": "verb",
-      "tip": ""
+      "tip": "",
+      "level": "Lv1"
     },
     {
       "id": "v018",
@@ -906,7 +1390,8 @@
       "jp": "問題",
       "en": "problem",
       "pos": "noun",
-      "tip": ""
+      "tip": "",
+      "level": "Lv1"
     },
     {
       "id": "v019",
@@ -914,7 +1399,8 @@
       "jp": "十分に",
       "en": "enough",
       "pos": "adverb",
-      "tip": ""
+      "tip": "",
+      "level": "Lv1"
     },
     {
       "id": "v020",
@@ -922,7 +1408,8 @@
       "jp": "驚く",
       "en": "surprised",
       "pos": "adjective",
-      "tip": ""
+      "tip": "",
+      "level": "Lv1"
     },
     {
       "id": "v021",
@@ -930,7 +1417,8 @@
       "jp": "有名な",
       "en": "famous",
       "pos": "adjective",
-      "tip": ""
+      "tip": "",
+      "level": "Lv1"
     },
     {
       "id": "v022",
@@ -938,7 +1426,8 @@
       "jp": "～なしで",
       "en": "without",
       "pos": "preposition",
-      "tip": ""
+      "tip": "",
+      "level": "Lv1"
     },
     {
       "id": "v023",
@@ -946,7 +1435,8 @@
       "jp": "文化",
       "en": "culture",
       "pos": "noun",
-      "tip": ""
+      "tip": "",
+      "level": "Lv1"
     },
     {
       "id": "v024",
@@ -954,7 +1444,8 @@
       "jp": "自然",
       "en": "nature",
       "pos": "noun",
-      "tip": ""
+      "tip": "",
+      "level": "Lv1"
     },
     {
       "id": "v025",
@@ -962,7 +1453,8 @@
       "jp": "お互いに",
       "en": "each other",
       "pos": "pronoun",
-      "tip": ""
+      "tip": "",
+      "level": "Lv1"
     },
     {
       "id": "v026",
@@ -970,7 +1462,8 @@
       "jp": "服",
       "en": "clothes",
       "pos": "noun",
-      "tip": ""
+      "tip": "",
+      "level": "Lv1"
     },
     {
       "id": "v027",
@@ -978,7 +1471,8 @@
       "jp": "理由",
       "en": "reason",
       "pos": "noun",
-      "tip": ""
+      "tip": "",
+      "level": "Lv1"
     },
     {
       "id": "v028",
@@ -986,7 +1480,8 @@
       "jp": "野菜",
       "en": "vegetable",
       "pos": "noun",
-      "tip": ""
+      "tip": "",
+      "level": "Lv1"
     },
     {
       "id": "v029",
@@ -994,7 +1489,8 @@
       "jp": "変な",
       "en": "strange",
       "pos": "adjective",
-      "tip": ""
+      "tip": "",
+      "level": "Lv1"
     },
     {
       "id": "v030",
@@ -1002,7 +1498,8 @@
       "jp": "天気",
       "en": "weather",
       "pos": "noun",
-      "tip": ""
+      "tip": "",
+      "level": "Lv1"
     },
     {
       "id": "v031",
@@ -1010,7 +1507,8 @@
       "jp": "ちがい",
       "en": "difference",
       "pos": "noun",
-      "tip": ""
+      "tip": "",
+      "level": "Lv1"
     },
     {
       "id": "v032",
@@ -1018,7 +1516,8 @@
       "jp": "生まれる",
       "en": "born",
       "pos": "adjective",
-      "tip": ""
+      "tip": "",
+      "level": "Lv1"
     },
     {
       "id": "v033",
@@ -1026,7 +1525,8 @@
       "jp": "経験する",
       "en": "experience",
       "pos": "verb",
-      "tip": ""
+      "tip": "",
+      "level": "Lv1"
     },
     {
       "id": "v034",
@@ -1034,7 +1534,8 @@
       "jp": "明日",
       "en": "tomorrow",
       "pos": "adverb",
-      "tip": ""
+      "tip": "",
+      "level": "Lv1"
     },
     {
       "id": "v035",
@@ -1042,7 +1543,8 @@
       "jp": "上達する",
       "en": "improve",
       "pos": "verb",
-      "tip": ""
+      "tip": "",
+      "level": "Lv1"
     },
     {
       "id": "v036",
@@ -1050,7 +1552,8 @@
       "jp": "誇りに思う",
       "en": "proud",
       "pos": "adjective",
-      "tip": ""
+      "tip": "",
+      "level": "Lv1"
     },
     {
       "id": "v037",
@@ -1058,7 +1561,8 @@
       "jp": "～時間",
       "en": "hours",
       "pos": "noun",
-      "tip": ""
+      "tip": "",
+      "level": "Lv1"
     },
     {
       "id": "v038",
@@ -1066,7 +1570,8 @@
       "jp": "危険な",
       "en": "dangerous",
       "pos": "adjective",
-      "tip": ""
+      "tip": "",
+      "level": "Lv1"
     },
     {
       "id": "v039",
@@ -1074,7 +1579,8 @@
       "jp": "共有する",
       "en": "share",
       "pos": "verb",
-      "tip": ""
+      "tip": "",
+      "level": "Lv1"
     },
     {
       "id": "v040",
@@ -1082,7 +1588,8 @@
       "jp": "千",
       "en": "thousand",
       "pos": "numeral",
-      "tip": ""
+      "tip": "",
+      "level": "Lv1"
     },
     {
       "id": "v041",
@@ -1090,7 +1597,8 @@
       "jp": "見つける（結果が出た）",
       "en": "find",
       "pos": "verb",
-      "tip": ""
+      "tip": "",
+      "level": "Lv1"
     },
     {
       "id": "v042",
@@ -1098,7 +1606,8 @@
       "jp": "方法、道",
       "en": "way",
       "pos": "noun",
-      "tip": ""
+      "tip": "",
+      "level": "Lv1"
     },
     {
       "id": "v043",
@@ -1106,7 +1615,8 @@
       "jp": "国",
       "en": "country",
       "pos": "noun",
-      "tip": ""
+      "tip": "",
+      "level": "Lv1"
     },
     {
       "id": "v044",
@@ -1114,7 +1624,8 @@
       "jp": "場所",
       "en": "place",
       "pos": "noun",
-      "tip": ""
+      "tip": "",
+      "level": "Lv1"
     },
     {
       "id": "v045",
@@ -1122,7 +1633,8 @@
       "jp": "大きい",
       "en": "large",
       "pos": "adjective",
-      "tip": ""
+      "tip": "",
+      "level": "Lv1"
     },
     {
       "id": "v046",
@@ -1130,7 +1642,8 @@
       "jp": "保つ",
       "en": "keep",
       "pos": "verb",
-      "tip": ""
+      "tip": "",
+      "level": "Lv1"
     },
     {
       "id": "v047",
@@ -1138,7 +1651,8 @@
       "jp": "希望",
       "en": "hope",
       "pos": "noun",
-      "tip": ""
+      "tip": "",
+      "level": "Lv1"
     },
     {
       "id": "v048",
@@ -1146,7 +1660,8 @@
       "jp": "疲れる",
       "en": "tired",
       "pos": "adjective",
-      "tip": ""
+      "tip": "",
+      "level": "Lv1"
     },
     {
       "id": "v049",
@@ -1154,7 +1669,8 @@
       "jp": "到着する",
       "en": "arrive",
       "pos": "verb",
-      "tip": ""
+      "tip": "",
+      "level": "Lv1"
     },
     {
       "id": "v050",
@@ -1162,7 +1678,8 @@
       "jp": "心配する",
       "en": "worry",
       "pos": "verb",
-      "tip": ""
+      "tip": "",
+      "level": "Lv1"
     }
   ]
 }

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -79,6 +79,13 @@
             <option value="vocab" selected>単語（意味→スペル）</option>
           </select>
         </label>
+        <label class="row" style="gap:6px"><span class="muted">レベル</span>
+          <select id="level-filter">
+            <option value="Lv1" selected>Lv1（中学一年生相当）</option>
+            <option value="Lv2">Lv2（中学二年生相当）</option>
+            <option value="Lv3">Lv3（中学三年生相当）</option>
+          </select>
+        </label>
         <label class="row" style="gap:6px"><span class="muted">ユニット</span>
           <select id="unit-filter">
             <option value="">全ユニット</option>
@@ -90,6 +97,7 @@
       <div class="muted" style="margin-top:8px">
         並べ替え: <span class="kbd">1-9</span> で選択、<span class="kbd">Backspace</span> で戻す、<span class="kbd">Enter</span> で採点/次へ。<br>
         単語: 入力欄にスペルを入力（英字・大文字小文字は不問）。
+        <br>レベルの目安: Lv1＝中学一年生、Lv2＝中学二年生、Lv3＝中学三年生。
       </div>
     </section>
 
@@ -151,11 +159,14 @@
     const SUBJECT = 'english';
     const QUESTIONS_URL = `/data/${SUBJECT}/questions.json`; // Flaskで配信
     const DEFAULT_ENDPOINT = "/api/results";
+    const LEVEL_ORDER = ['Lv1','Lv2','Lv3'];
+    const DEFAULT_LEVEL = LEVEL_ORDER[0];
 
     // 設定の記憶用キー
     const REMEMBER_USER_KEY = 'quiz:lastUser';
     const REMEMBER_QTYPE_KEY = 'quiz:lastQType';
     const REMEMBER_UNIT_KEY = 'quiz:lastUnitFilter';
+    const REMEMBER_LEVEL_KEY = 'quiz:lastLevel';
     const USER_SUGGEST_KEY = 'quiz:userList';
 
     /********** 問題ロード **********/
@@ -190,6 +201,23 @@
       return unique;
     };
 
+    const normalizeLevel = (value)=>{
+      const str = (value==null ? '' : String(value)).trim();
+      if(LEVEL_ORDER.includes(str)) return str;
+      const match = str.match(/([1-3])/);
+      if(match){
+        const candidate = `Lv${match[1]}`;
+        if(LEVEL_ORDER.includes(candidate)) return candidate;
+      }
+      return DEFAULT_LEVEL;
+    };
+
+    const levelIndex = (value)=>{
+      const lvl = normalizeLevel(value);
+      const idx = LEVEL_ORDER.indexOf(lvl);
+      return idx === -1 ? LEVEL_ORDER.length : idx;
+    };
+
     const buildQuestion = (item, type)=>{
       const answers = collectAnswerSet(item);
       const primary = answers[0] || (typeof item.en==='string'? item.en.trim(): '');
@@ -201,7 +229,8 @@
         en: primary,
         answers,
         tip: item.tip||'',
-        explain: item.explain||''
+        explain: item.explain||'',
+        level: normalizeLevel(item.level)
       };
       if(type==='reorder'){
         base.chunks = item.chunks;
@@ -227,6 +256,7 @@
       user:'guest', endpoint: DEFAULT_ENDPOINT,
       qType:'reorder',
       unitFilter:'',
+      levelMax: DEFAULT_LEVEL,
       totalPerSet:5, order:[], setIndex:0,
       qIndex:0, correct:0, wrong:0,
       startedAt:null, seconds:0, timerId:null,
@@ -323,7 +353,7 @@
     function renderUnitFilterOptions(){
       const sel = document.getElementById('unit-filter');
       if(!sel) return;
-      const deckArr = deckByType(state.qType);
+      const deckArr = deckByType(state.qType).filter(q=> levelIndex(q.level) <= levelIndex(state.levelMax));
       const units = Array.from(new Set(deckArr.map(q=>normalizeUnit(q.unit)).filter(u=>u))).sort((a,b)=>a.localeCompare(b, 'ja', { numeric:true, sensitivity:'base' }));
       sel.innerHTML='';
       const optAll=document.createElement('option'); optAll.value=''; optAll.textContent='全ユニット'; sel.appendChild(optAll);
@@ -331,6 +361,10 @@
       if(deckArr.length===0){
         sel.value='';
         sel.disabled=true;
+        if(state.unitFilter){
+          state.unitFilter='';
+          rememberUnitFilter(state.qType, '');
+        }
         return;
       }
       sel.disabled=false;
@@ -346,6 +380,11 @@
       const qt=(localStorage.getItem(REMEMBER_QTYPE_KEY)||'').trim();
       const qs=document.getElementById('qtype');
       if(qt){ state.qType=qt; if(qs) qs.value=qt; }
+      const levelSel = document.getElementById('level-filter');
+      const rememberedLevel = (localStorage.getItem(REMEMBER_LEVEL_KEY)||DEFAULT_LEVEL).trim();
+      const normalizedLevel = LEVEL_ORDER.includes(rememberedLevel) ? rememberedLevel : DEFAULT_LEVEL;
+      state.levelMax = normalizedLevel;
+      if(levelSel){ levelSel.value = normalizedLevel; }
       state.unitFilter = getRememberedUnitFilter(state.qType);
       const unitSel = document.getElementById('unit-filter');
       if(unitSel){ unitSel.value = state.unitFilter || ''; }
@@ -355,6 +394,7 @@
     function rememberSettings(){
       if(state.user) localStorage.setItem(REMEMBER_USER_KEY, state.user);
       if(state.qType) localStorage.setItem(REMEMBER_QTYPE_KEY, state.qType);
+      localStorage.setItem(REMEMBER_LEVEL_KEY, state.levelMax || DEFAULT_LEVEL);
       rememberUnitFilter(state.qType, state.unitFilter||'');
       const raw=JSON.parse(localStorage.getItem(USER_SUGGEST_KEY)||'[]');
       const list=Array.isArray(raw)? raw.slice(0) : [];
@@ -384,10 +424,13 @@
     function deckByType(type){ return type==='reorder' ? BANK_REORDER : BANK_VOCAB; }
     function deck(){
       const all = deckByType(state.qType);
-      if(state.mode!=='normal') return all;
-      const unit = state.unitFilter || '';
-      if(!unit) return all;
-      return all.filter(q=> normalizeUnit(q.unit) === unit);
+      if(state.mode==='review') return all;
+      const maxLevelIdx = levelIndex(state.levelMax);
+      const byLevel = all.filter(q=> levelIndex(q.level) <= maxLevelIdx);
+      const shouldFilterByUnit = state.mode==='normal' || state.mode==='weak';
+      const unit = shouldFilterByUnit ? (state.unitFilter || '') : '';
+      if(!unit) return byLevel;
+      return byLevel.filter(q=> normalizeUnit(q.unit) === unit);
     }
 
     /********** セット準備 **********/
@@ -554,7 +597,7 @@
       if(!fullDeck.length){ alert(`この出題タイプの問題がありません。/data/${SUBJECT}/questions.json をご確認ください。`); show('setup'); return; }
       const filteredDeck = deck();
       if(state.mode==='normal' && !filteredDeck.length){
-        alert('選択したユニットの問題がありません。ユニット条件を見直してください。');
+        alert('選択したレベル／ユニットの条件に合う問題がありません。条件を見直してください。');
         show('setup');
         return;
       }
@@ -704,7 +747,7 @@
           ? `❌ 不正解。 正解: ${answersMarkup}${detail}`
           : `❌ 不正解。 正解: ${answersMarkup}${detail}`;
         // 復習用には詳細保持
-        addWrongLocal({ type:state.qType, id:q.id||null, unit:q.unit||null, jp:q.jp, en:q.en, chunks:q.chunks, tip:q.tip||'', explain:q.explain||'', userAnswer: ans, at: record.at });
+        addWrongLocal({ type:state.qType, id:q.id||null, unit:q.unit||null, level:q.level||DEFAULT_LEVEL, jp:q.jp, en:q.en, chunks:q.chunks, tip:q.tip||'', explain:q.explain||'', userAnswer: ans, at: record.at });
       }
 
       (state.mode==='review'? state.reviewed : state.answered).push(record);
@@ -805,6 +848,11 @@
         state.totalPerSet=Math.max(3,Math.min(20,parseInt(document.getElementById('count').value||5,10)));
         state.endpoint=DEFAULT_ENDPOINT;
         state.setIndex=0; state.mode='normal'; state.qType=document.getElementById('qtype').value||'reorder';
+        const levelSel=document.getElementById('level-filter');
+        if(levelSel){
+          state.levelMax = normalizeLevel(levelSel.value||DEFAULT_LEVEL);
+          levelSel.value = state.levelMax;
+        }
         const unitSel=document.getElementById('unit-filter');
         if(unitSel){
           const selected=(unitSel.value||'').trim();
@@ -830,6 +878,11 @@
         state.totalPerSet=Math.max(3,Math.min(20,parseInt(document.getElementById('count').value||5,10)));
         state.endpoint=DEFAULT_ENDPOINT;
         state.setIndex=0; state.mode='weak'; state.qType=document.getElementById('qtype').value||'reorder';
+        const levelSel=document.getElementById('level-filter');
+        if(levelSel){
+          state.levelMax = normalizeLevel(levelSel.value||DEFAULT_LEVEL);
+          levelSel.value = state.levelMax;
+        }
         const unitSel=document.getElementById('unit-filter');
         if(unitSel){
           const selected=(unitSel.value||'').trim();
@@ -851,6 +904,16 @@
     document.getElementById('unit-filter').addEventListener('change', (e)=>{
       const v=(e.target.value||'').trim();
       state.unitFilter=v;
+      rememberSettings();
+    });
+    document.getElementById('level-filter').addEventListener('change', (e)=>{
+      const selected = normalizeLevel(e.target.value||DEFAULT_LEVEL);
+      state.levelMax = selected;
+      const levelSel = document.getElementById('level-filter');
+      if(levelSel) levelSel.value = selected;
+      renderUnitFilterOptions();
+      const unitSel = document.getElementById('unit-filter');
+      if(unitSel){ state.unitFilter = (unitSel.value||'').trim(); }
       rememberSettings();
     });
     document.getElementById('qtype').addEventListener('change', async (e)=>{


### PR DESCRIPTION
## Summary
- set all non-conjunction questions and all vocabulary entries to Lv1
- keep conjunction-and/but questions at Lv1 while moving other conjunction questions to Lv2 to match the new policy

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e0cefa740c8333ab7717674c7cb1b1