### PR TITLE
Expose question attempt timestamps to improve bucket selection

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -75,9 +75,7 @@ def save_results():
     try:
         stage_tracker.update_store_from_session(target_dir, rec)
     except Exception:
-        app.logger.exception(
-            "failed to update stage cache for subject=%s", subject
-        )
+        app.logger.exception("failed to update stage cache for subject=%s", subject)
 
     return jsonify({"ok": True}), 201
 
@@ -623,9 +621,7 @@ def admin_summary():
 
     if user not in (None, "", "__all__"):
         for item in question_stats:
-            state = stage_tracker.get_question_state(
-                stage_store, user, item.get("id")
-            )
+            state = stage_tracker.get_question_state(stage_store, user, item.get("id"))
             if state:
                 item["stage"] = state.get("stage")
                 item["nextDueAt"] = state.get("nextDueAt")

--- a/app/stage_tracker.py
+++ b/app/stage_tracker.py
@@ -1,0 +1,249 @@
+import json
+import os
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+STAGE_SEQUENCE = ("F", "E", "D", "C", "B", "A")
+
+NEXT_STAGE_RULES: Dict[str, Dict[str, Any]] = {
+    "F": {"next": "E", "gap_days": None, "min_streak": 3},
+    "E": {"next": "D", "gap_days": 2},
+    "D": {"next": "C", "gap_days": 3},
+    "C": {"next": "B", "gap_days": 7},
+    "B": {"next": "A", "gap_days": 14},
+    "A": {},
+}
+
+
+def _default_question_state() -> Dict[str, Any]:
+    return {
+        "stage": "F",
+        "streak": 0,
+        "answered": 0,
+        "correct": 0,
+        "lastCorrectAt": None,
+        "lastWrongAt": None,
+        "lastAttemptAt": None,
+        "nextDueAt": None,
+        "updatedAt": None,
+    }
+
+
+def _normalize_user(user: str) -> str:
+    value = (user or "").strip()
+    return value or "guest"
+
+
+def _normalize_qid(qid: Any) -> Optional[str]:
+    if qid in (None, ""):
+        return None
+    return str(qid)
+
+
+def _parse_iso(dt_str: Optional[str]) -> Optional[datetime]:
+    if not dt_str:
+        return None
+    try:
+        dt = datetime.fromisoformat(dt_str.replace("Z", "+00:00"))
+    except Exception:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _to_iso(dt: Optional[datetime]) -> Optional[str]:
+    if not dt:
+        return None
+    return dt.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+def _compute_next_due(stage: str, reference: Optional[datetime]) -> Optional[str]:
+    rules = NEXT_STAGE_RULES.get(stage, {})
+    gap_days = rules.get("gap_days")
+    if not reference or gap_days in (None, 0):
+        return None
+    try:
+        delta = timedelta(days=float(gap_days))
+    except Exception:
+        return None
+    return _to_iso(reference + delta)
+
+
+def _apply_correct(state: Dict[str, Any], attempt_dt: datetime) -> None:
+    prev_last_correct = _parse_iso(state.get("lastCorrectAt"))
+    state["streak"] = int(state.get("streak") or 0) + 1
+
+    stage = state.get("stage") or "F"
+    stage_rules = NEXT_STAGE_RULES.get(stage, {})
+
+    if stage == "F":
+        min_streak = stage_rules.get("min_streak") or 0
+        if state["streak"] >= min_streak and min_streak > 0:
+            stage = stage_rules.get("next", stage)
+    else:
+        gap_days_req = stage_rules.get("gap_days")
+        next_stage = stage_rules.get("next")
+        if (
+            next_stage
+            and gap_days_req is not None
+            and prev_last_correct is not None
+        ):
+            gap = (attempt_dt - prev_last_correct).total_seconds() / 86400.0
+            if gap >= float(gap_days_req):
+                stage = next_stage
+
+    state["stage"] = stage if stage in STAGE_SEQUENCE else "F"
+    state["lastCorrectAt"] = _to_iso(attempt_dt)
+    state["nextDueAt"] = _compute_next_due(state["stage"], attempt_dt)
+
+
+def _apply_wrong(state: Dict[str, Any], attempt_dt: datetime) -> None:
+    state["stage"] = "F"
+    state["streak"] = 0
+    state["lastWrongAt"] = _to_iso(attempt_dt)
+    state["nextDueAt"] = None
+
+
+def _apply_attempt(
+    state: Dict[str, Any],
+    attempt_dt: Optional[datetime],
+    is_correct: bool,
+) -> bool:
+    if not attempt_dt:
+        return False
+    before = state.copy()
+
+    state["answered"] = int(state.get("answered") or 0) + 1
+    if is_correct:
+        state["correct"] = int(state.get("correct") or 0) + 1
+        _apply_correct(state, attempt_dt)
+    else:
+        _apply_wrong(state, attempt_dt)
+    state["lastAttemptAt"] = _to_iso(attempt_dt)
+    state["updatedAt"] = state["lastAttemptAt"]
+
+    return state != before
+
+
+def _stage_file_path(runtime_dir: str) -> str:
+    return os.path.join(runtime_dir, "stages.json")
+
+
+def load_store(runtime_dir: str) -> Dict[str, Dict[str, Dict[str, Any]]]:
+    path = _stage_file_path(runtime_dir)
+    if not os.path.exists(path):
+        return {}
+    try:
+        with open(path, encoding="utf-8") as fp:
+            data = json.load(fp)
+    except Exception:
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    return data
+
+
+def save_store(runtime_dir: str, store: Dict[str, Dict[str, Dict[str, Any]]]) -> None:
+    path = _stage_file_path(runtime_dir)
+    os.makedirs(runtime_dir, exist_ok=True)
+    tmp_path = f"{path}.tmp"
+    with open(tmp_path, "w", encoding="utf-8") as fp:
+        json.dump(store, fp, ensure_ascii=False, separators=(",", ":"))
+    os.replace(tmp_path, path)
+
+
+def _ensure_state(store: Dict[str, Any], user: str, qid: str) -> Dict[str, Any]:
+    user_key = _normalize_user(user)
+    qid_key = _normalize_qid(qid)
+    if qid_key is None:
+        raise ValueError("question id is required")
+    user_bucket = store.setdefault(user_key, {})
+    state = user_bucket.get(qid_key)
+    if not isinstance(state, dict):
+        state = _default_question_state()
+        user_bucket[qid_key] = state
+    return state
+
+
+def _iter_session_attempts(record: Dict[str, Any]) -> Iterable[Tuple[datetime, Dict[str, Any]]]:
+    mode = (record.get("mode") or "normal").lower()
+    if mode == "review":
+        return []
+    answered = record.get("answered") or []
+    if not isinstance(answered, list):
+        return []
+
+    attempts: List[Tuple[datetime, Dict[str, Any]]] = []
+    fallback_time = record.get("endedAt") or record.get("receivedAt")
+    for item in answered:
+        if not isinstance(item, dict):
+            continue
+        attempt_mode = (item.get("mode") or mode).lower()
+        if attempt_mode == "review":
+            continue
+        qid = _normalize_qid(item.get("id"))
+        if qid is None:
+            continue
+        at_str = item.get("at") or fallback_time
+        dt = _parse_iso(at_str)
+        if not dt:
+            continue
+        attempts.append((dt, item))
+    attempts.sort(key=lambda x: x[0])
+    return attempts
+
+
+def apply_session(store: Dict[str, Any], record: Dict[str, Any]) -> bool:
+    user = _normalize_user(record.get("user"))
+    changed = False
+    for attempt_dt, payload in _iter_session_attempts(record):
+        qid = _normalize_qid(payload.get("id"))
+        if qid is None:
+            continue
+        try:
+            state = _ensure_state(store, user, qid)
+        except ValueError:
+            continue
+        ok = bool(payload.get("correct"))
+        changed |= _apply_attempt(state, attempt_dt, ok)
+    return changed
+
+
+def update_store_from_session(runtime_dir: str, record: Dict[str, Any]) -> None:
+    store = load_store(runtime_dir)
+    changed = apply_session(store, record)
+    if changed:
+        save_store(runtime_dir, store)
+
+
+def rebuild_store(runtime_dir: str, records: Iterable[Dict[str, Any]]) -> Dict[str, Any]:
+    ordered: List[Tuple[datetime, Dict[str, Any]]] = []
+    for rec in records:
+        fallback = rec.get("endedAt") or rec.get("receivedAt")
+        dt = _parse_iso(fallback)
+        if not dt:
+            dt = datetime.now(timezone.utc)
+        ordered.append((dt, rec))
+    ordered.sort(key=lambda x: x[0])
+
+    store: Dict[str, Any] = {}
+    for _, rec in ordered:
+        apply_session(store, rec)
+    save_store(runtime_dir, store)
+    return store
+
+
+def get_question_state(
+    store: Dict[str, Any], user: str, qid: str
+) -> Optional[Dict[str, Any]]:
+    user_key = _normalize_user(user)
+    qid_key = _normalize_qid(qid)
+    if qid_key is None:
+        return None
+    user_bucket = store.get(user_key)
+    if not isinstance(user_bucket, dict):
+        return None
+    state = user_bucket.get(qid_key)
+    if not isinstance(state, dict):
+        return None
+    return state

--- a/app/stage_tracker.py
+++ b/app/stage_tracker.py
@@ -57,6 +57,7 @@ def _to_iso(dt: Optional[datetime]) -> Optional[str]:
         return None
     return dt.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
 
+
 def _compute_next_due(stage: str, reference: Optional[datetime]) -> Optional[str]:
     rules = NEXT_STAGE_RULES.get(stage, {})
     gap_days = rules.get("gap_days")
@@ -83,11 +84,7 @@ def _apply_correct(state: Dict[str, Any], attempt_dt: datetime) -> None:
     else:
         gap_days_req = stage_rules.get("gap_days")
         next_stage = stage_rules.get("next")
-        if (
-            next_stage
-            and gap_days_req is not None
-            and prev_last_correct is not None
-        ):
+        if next_stage and gap_days_req is not None and prev_last_correct is not None:
             gap = (attempt_dt - prev_last_correct).total_seconds() / 86400.0
             if gap >= float(gap_days_req):
                 stage = next_stage
@@ -165,7 +162,9 @@ def _ensure_state(store: Dict[str, Any], user: str, qid: str) -> Dict[str, Any]:
     return state
 
 
-def _iter_session_attempts(record: Dict[str, Any]) -> Iterable[Tuple[datetime, Dict[str, Any]]]:
+def _iter_session_attempts(
+    record: Dict[str, Any],
+) -> Iterable[Tuple[datetime, Dict[str, Any]]]:
     mode = (record.get("mode") or "normal").lower()
     if mode == "review":
         return []
@@ -216,7 +215,9 @@ def update_store_from_session(runtime_dir: str, record: Dict[str, Any]) -> None:
         save_store(runtime_dir, store)
 
 
-def rebuild_store(runtime_dir: str, records: Iterable[Dict[str, Any]]) -> Dict[str, Any]:
+def rebuild_store(
+    runtime_dir: str, records: Iterable[Dict[str, Any]]
+) -> Dict[str, Any]:
     ordered: List[Tuple[datetime, Dict[str, Any]]] = []
     for rec in records:
         fallback = rec.get("endedAt") or rec.get("receivedAt")

--- a/app/static/admin.html
+++ b/app/static/admin.html
@@ -103,13 +103,13 @@
       <div class="card" id="sec-vocab">
         <h3 style="margin:0 0 8px">単語問題</h3>
         <div style="max-height:340px; overflow:auto">
-          <table id="tbl-words-vocab"><thead><tr><th>ID</th><th>日本語</th><th>英語</th><th class="center">正答</th><th class="center">誤答</th><th class="center">連続正解</th><th class="center">正答率</th></tr></thead><tbody></tbody></table>
+          <table id="tbl-words-vocab"><thead><tr><th>ID</th><th>日本語</th><th>英語</th><th class="center">正答</th><th class="center">誤答</th><th class="center">ランク</th><th class="center">次回</th><th class="center">連続正解</th><th class="center">正答率</th></tr></thead><tbody></tbody></table>
         </div>
       </div>
       <div class="card" id="sec-reorder">
         <h3 style="margin:0 0 8px">並べ替え問題</h3>
         <div style="max-height:340px; overflow:auto">
-          <table id="tbl-words-reorder"><thead><tr><th>ID</th><th>日本語</th><th>英語</th><th class="center">正答</th><th class="center">誤答</th><th class="center">連続正解</th><th class="center">正答率</th></tr></thead><tbody></tbody></table>
+          <table id="tbl-words-reorder"><thead><tr><th>ID</th><th>日本語</th><th>英語</th><th class="center">正答</th><th class="center">誤答</th><th class="center">ランク</th><th class="center">次回</th><th class="center">連続正解</th><th class="center">正答率</th></tr></thead><tbody></tbody></table>
         </div>
       </div>
     </section>
@@ -240,11 +240,15 @@
       data.questionStats.forEach(q=>{
         const acc = q.answered? Math.round(q.correct/q.answered*100):0;
         const tr=document.createElement('tr');
+        const stageCell = q.stage ? `<span class="badge">${q.stage}</span>` : '<span class="muted">--</span>';
+        const dueText = q.nextDueAt ? new Date(q.nextDueAt).toLocaleDateString() : '―';
         tr.innerHTML = `<td>${q.id||''}</td>
                         <td>${q.jp||''}</td>
                         <td>${q.en||''}</td>
                         <td class="center ok">${fmt(q.correct)}</td>
                         <td class="center ng">${fmt(q.wrong)}</td>
+                        <td class="center">${stageCell}</td>
+                        <td class="center">${dueText}</td>
                         <td class="center">${fmt(q.streak||0)}</td>
                         <td class="center">${acc}%</td>`;
         if(q.type==='vocab') qVocab.appendChild(tr); else qReorder.appendChild(tr);

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -433,6 +433,17 @@
       return byLevel.filter(q=> normalizeUnit(q.unit) === unit);
     }
 
+    function parseIsoDate(value){
+      if(!value) return null;
+      const date = new Date(value);
+      return Number.isNaN(date.getTime()) ? null : date;
+    }
+
+    function isSameCalendarDay(a,b){
+      if(!(a instanceof Date) || !(b instanceof Date)) return false;
+      return a.getFullYear()===b.getFullYear() && a.getMonth()===b.getMonth() && a.getDate()===b.getDate();
+    }
+
     /********** セット準備 **********/
     async function buildOrderFromBank(){
       const deckArr = deck();
@@ -457,7 +468,11 @@
 
       for(let i=0;i<deckArr.length;i++){
         const s = stats[i];
-        if(!s){ bucketB.push({idx:i, streak:0}); continue; }
+        if(!s || typeof s !== 'object'){ bucketB.push({idx:i, streak:0}); continue; }
+        const lastWrong = parseIsoDate(s.lastWrongAt);
+        const lastCorrect = parseIsoDate(s.lastCorrectAt);
+        const recoveredSameDay = lastWrong && lastCorrect && isSameCalendarDay(lastWrong, lastCorrect) && lastCorrect.getTime() >= lastWrong.getTime();
+        if(recoveredSameDay){ bucketB.push({idx:i, streak:0}); continue; }
         const streak = s.streak||0;
         const ans = s.answered||0;
         const ok = s.correct||0;

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -72,5 +72,11 @@ def test_stats_endpoint_excludes_review_and_counts_all(tmp_path, monkeypatch):
     res = client.get("/api/stats", query_string={"user": "alice", "id": "q1"})
     assert res.status_code == 200
     data = res.get_json()
-    assert data == {"answered": 3, "correct": 2, "streak": 2}
+    assert data == {
+        "answered": 3,
+        "correct": 2,
+        "streak": 2,
+        "lastWrongAt": (now - timedelta(days=40)).isoformat().replace("+00:00", "Z"),
+        "lastCorrectAt": now.isoformat().replace("+00:00", "Z"),
+    }
     sys.modules.pop("app.app", None)

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -11,6 +11,7 @@ def test_stats_endpoint_excludes_review_and_counts_all(tmp_path, monkeypatch):
     mod = importlib.import_module("app.app")
     flask_app = mod.app
     client = flask_app.test_client()
+
     now = datetime.now(timezone.utc)
     recs = [
         {
@@ -69,6 +70,7 @@ def test_stats_endpoint_excludes_review_and_counts_all(tmp_path, monkeypatch):
     with open(path, "w", encoding="utf-8") as f:
         for r in recs:
             f.write(json.dumps(r) + "\n")
+
     res = client.get("/api/stats", query_string={"user": "alice", "id": "q1"})
     assert res.status_code == 200
     data = res.get_json()
@@ -78,5 +80,106 @@ def test_stats_endpoint_excludes_review_and_counts_all(tmp_path, monkeypatch):
         "streak": 2,
         "lastWrongAt": (now - timedelta(days=40)).isoformat().replace("+00:00", "Z"),
         "lastCorrectAt": now.isoformat().replace("+00:00", "Z"),
+        "stage": "F",
+        "nextDueAt": None,
+    }
+    sys.modules.pop("app.app", None)
+
+
+def test_stage_progression_updates_on_result_post(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    import importlib
+    import sys
+
+    sys.modules.pop("app.app", None)
+    mod = importlib.import_module("app.app")
+    flask_app = mod.app
+    client = flask_app.test_client()
+
+    base = datetime(2024, 1, 1, tzinfo=timezone.utc)
+
+    def iso(dt):
+        return dt.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+    session_one = {
+        "user": "alice",
+        "mode": "normal",
+        "endedAt": iso(base + timedelta(minutes=2)),
+        "answered": [
+            {"id": "q1", "correct": True, "at": iso(base)},
+            {"id": "q1", "correct": True, "at": iso(base + timedelta(minutes=1))},
+            {"id": "q1", "correct": True, "at": iso(base + timedelta(minutes=2))},
+        ],
+    }
+
+    res = client.post("/api/results", json=session_one)
+    assert res.status_code == 201
+
+    stage_path = tmp_path / "english" / "stages.json"
+    with open(stage_path, encoding="utf-8") as fp:
+        store = json.load(fp)
+    state = store["alice"]["q1"]
+    assert state["stage"] == "E"
+    assert state["streak"] == 3
+    assert state["answered"] == 3
+    assert state["correct"] == 3
+    expected_last_correct = iso(base + timedelta(minutes=2))
+    assert state["lastCorrectAt"] == expected_last_correct
+    assert state["nextDueAt"] == iso(base + timedelta(minutes=2) + timedelta(days=2))
+
+    session_two = {
+        "user": "alice",
+        "mode": "normal",
+        "endedAt": iso(base + timedelta(days=4)),
+        "answered": [
+            {"id": "q1", "correct": True, "at": iso(base + timedelta(days=4))},
+        ],
+    }
+
+    res = client.post("/api/results", json=session_two)
+    assert res.status_code == 201
+
+    with open(stage_path, encoding="utf-8") as fp:
+        store = json.load(fp)
+    state = store["alice"]["q1"]
+    assert state["stage"] == "D"
+    assert state["streak"] == 4
+    assert state["correct"] == 4
+    assert state["nextDueAt"] == iso(base + timedelta(days=4) + timedelta(days=3))
+
+    session_three = {
+        "user": "alice",
+        "mode": "normal",
+        "endedAt": iso(base + timedelta(days=5)),
+        "answered": [
+            {"id": "q1", "correct": False, "at": iso(base + timedelta(days=5))},
+        ],
+    }
+
+    res = client.post("/api/results", json=session_three)
+    assert res.status_code == 201
+
+    with open(stage_path, encoding="utf-8") as fp:
+        store = json.load(fp)
+    state = store["alice"]["q1"]
+    assert state["stage"] == "F"
+    assert state["streak"] == 0
+    assert state["answered"] == 5
+    assert state["correct"] == 4
+    assert state["lastWrongAt"] == iso(base + timedelta(days=5))
+    assert state["lastCorrectAt"] == iso(base + timedelta(days=4))
+    assert state["nextDueAt"] is None
+
+    stats = client.get("/api/stats", query_string={"user": "alice", "id": "q1"})
+    assert stats.status_code == 200
+    payload = stats.get_json()
+    assert payload == {
+        "answered": 5,
+        "correct": 4,
+        "streak": 0,
+        "lastWrongAt": iso(base + timedelta(days=5)),
+        "lastCorrectAt": iso(base + timedelta(days=4)),
+        "stage": "F",
+        "nextDueAt": None,
     }
     sys.modules.pop("app.app", None)


### PR DESCRIPTION
## Summary
- extend the /api/stats response with lastWrongAt and lastCorrectAt timestamps
- use the new timestamps on the front-end to keep same-day recoveries in bucket B
- update the stats endpoint test to cover the new response fields

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e137f128b883339264b79dbfb5710f