### PR TITLE
Prioritize stage upgrade questions when building quiz sets

### DIFF
--- a/app/static/index.html
+++ b/app/static/index.html
@@ -434,15 +434,26 @@
       return byLevel.filter(q=> normalizeUnit(q.unit) === unit);
     }
 
+    const STAGE_PRIORITY = ['A','B','C','D','E'];
+
     function parseIsoDate(value){
       if(!value) return null;
       const date = new Date(value);
       return Number.isNaN(date.getTime()) ? null : date;
     }
 
-    function isSameCalendarDay(a,b){
-      if(!(a instanceof Date) || !(b instanceof Date)) return false;
-      return a.getFullYear()===b.getFullYear() && a.getMonth()===b.getMonth() && a.getDate()===b.getDate();
+    function normalizeStage(value){
+      if(typeof value !== 'string') return 'F';
+      const upper = value.trim().toUpperCase();
+      if(STAGE_PRIORITY.includes(upper) || upper === 'F') return upper;
+      return 'F';
+    }
+
+    function willStageUpOnSuccess(stage, nextDue, now){
+      if(!STAGE_PRIORITY.includes(stage)) return false;
+      if(stage === 'A') return false;
+      if(!(nextDue instanceof Date)) return true;
+      return nextDue.getTime() <= now;
     }
 
     /********** セット準備 **********/
@@ -450,67 +461,110 @@
       const deckArr = deck();
       const n = Math.min(state.totalPerSet, deckArr.length);
 
-      // バケット：
-      // A: サーバ記録で直近の回答が正解の問題
-      // B: それ以外（誤答または未回答）の問題
-      const bucketA = [];
-      const bucketB = [];
+        const dueByStage = new Map(STAGE_PRIORITY.map(stage=>[stage, []]));
+        const stageFPool = [];
+        const waitingPool = [];
 
-      // サーバから各問題の統計を取得
-      const stats = await Promise.all(
-        deckArr.map(q=>{
-          if(!state.user || !q.id) return Promise.resolve(null);
-          const url = `/api/stats?user=${encodeURIComponent(state.user)}&id=${encodeURIComponent(q.id)}&subject=${encodeURIComponent(SUBJECT)}`;
-          return fetch(url,{cache:'no-store'})
-            .then(r=>r.ok?r.json():null)
-            .catch(()=>null);
-        })
-      );
+        // サーバから各問題の統計を取得
+        const stats = await Promise.all(
+          deckArr.map(q=>{
+            if(!state.user || !q.id) return Promise.resolve(null);
+            const url = `/api/stats?user=${encodeURIComponent(state.user)}&id=${encodeURIComponent(q.id)}&subject=${encodeURIComponent(SUBJECT)}`;
+            return fetch(url,{cache:'no-store'})
+              .then(r=>r.ok?r.json():null)
+              .catch(()=>null);
+          })
+        );
 
-      for(let i=0;i<deckArr.length;i++){
-        const s = stats[i];
-        if(!s || typeof s !== 'object'){ bucketB.push({idx:i, streak:0}); continue; }
-        const lastWrong = parseIsoDate(s.lastWrongAt);
-        const lastCorrect = parseIsoDate(s.lastCorrectAt);
-        const recoveredSameDay = lastWrong && lastCorrect && isSameCalendarDay(lastWrong, lastCorrect) && lastCorrect.getTime() >= lastWrong.getTime();
-        if(recoveredSameDay){ bucketB.push({idx:i, streak:0}); continue; }
-        const streak = s.streak||0;
-        const ans = s.answered||0;
-        const ok = s.correct||0;
-        const accuracy = ans? (ok/ans) : 0;
-        if(streak>0){
-          bucketA.push({ idx:i, streak, accuracy, rand:Math.random() });
-        }else{
-          bucketB.push({idx:i, streak:0});
+        const now = Date.now();
+
+        for(let i=0;i<deckArr.length;i++){
+          const s = stats[i];
+          if(!s || typeof s !== 'object'){
+            stageFPool.push({idx:i, streak:0});
+            continue;
+          }
+
+          const stage = normalizeStage(s.stage);
+          const rawStreak = Number(s.streak);
+          const streak = Number.isFinite(rawStreak) ? rawStreak : 0;
+          const nextDue = parseIsoDate(s.nextDueAt);
+
+          if(willStageUpOnSuccess(stage, nextDue, now)){
+            const arr = dueByStage.get(stage);
+            if(arr){
+              arr.push({ idx:i, stage, streak, nextDue, rand:Math.random() });
+              continue;
+            }
+          }
+
+          if(stage === 'F'){
+            stageFPool.push({ idx:i, streak });
+          }else if(STAGE_PRIORITY.includes(stage)){
+            waitingPool.push({ idx:i, stage, streak, nextDue, rand:Math.random() });
+          }else{
+            stageFPool.push({ idx:i, streak });
+          }
         }
+
+        const order = [];
+        const chosen = new Set();
+
+        for(const stage of STAGE_PRIORITY){
+          const arr = dueByStage.get(stage) || [];
+          arr.sort((a,b)=>{
+            const aDue = a.nextDue instanceof Date ? a.nextDue.getTime() : -Infinity;
+            const bDue = b.nextDue instanceof Date ? b.nextDue.getTime() : -Infinity;
+            if(aDue !== bDue) return aDue - bDue;
+            return a.rand - b.rand;
+          });
+          for(const entry of arr){
+            if(order.length >= n) break;
+            if(chosen.has(entry.idx)) continue;
+            order.push({ idx:entry.idx, bucket:`Stage ${entry.stage}`, streak:entry.streak });
+            chosen.add(entry.idx);
+          }
+          if(order.length >= n) break;
+        }
+
+        const shuffledF = shuffle(stageFPool);
+        for(const entry of shuffledF){
+          if(order.length >= n) break;
+          if(chosen.has(entry.idx)) continue;
+          order.push({ idx:entry.idx, bucket:'Stage F', streak:entry.streak });
+          chosen.add(entry.idx);
+        }
+
+        if(order.length < n){
+          waitingPool.sort((a,b)=>{
+            const aDue = a.nextDue instanceof Date ? a.nextDue.getTime() : Infinity;
+            const bDue = b.nextDue instanceof Date ? b.nextDue.getTime() : Infinity;
+            if(aDue !== bDue) return aDue - bDue;
+            return a.rand - b.rand;
+          });
+          for(const entry of waitingPool){
+            if(order.length >= n) break;
+            if(chosen.has(entry.idx)) continue;
+            order.push({ idx:entry.idx, bucket:`Stage ${entry.stage}`, streak:entry.streak });
+            chosen.add(entry.idx);
+          }
+        }
+
+        if(order.length < n){
+          const remaining = [];
+          for(let i=0;i<deckArr.length;i++){
+            if(!chosen.has(i)) remaining.push({ idx:i, rand:Math.random() });
+          }
+          remaining.sort((a,b)=>a.rand-b.rand);
+          for(const entry of remaining){
+            if(order.length >= n) break;
+            order.push({ idx:entry.idx, bucket:null, streak:0 });
+            chosen.add(entry.idx);
+          }
+        }
+
+        return order;
       }
-
-      // 連続正解数の少ない順 → 正解率の低い順 → 乱数
-      const compareA = (a, b) =>
-        (a.streak - b.streak) || (a.accuracy - b.accuracy) || (a.rand - b.rand);
-
-      const order = [];
-      bucketA.sort(compareA);
-      if(bucketA.length>0){
-        const picked = bucketA.shift();
-        order.push({ idx:picked.idx, bucket:'A', streak:picked.streak });
-      }
-
-      const B = shuffle(bucketB); // ランダム
-      while(order.length < n && B.length){
-        const b = B.shift();
-        order.push({ idx:b.idx, bucket:'B', streak:b.streak });
-      }
-
-      bucketA.forEach(x=>x.rand=Math.random());
-      bucketA.sort(compareA);
-      while(order.length < n && bucketA.length){
-        const next = bucketA.shift();
-        order.push({ idx:next.idx, bucket:'A', streak:next.streak });
-      }
-
-      return order;
-    }
 
 
 


### PR DESCRIPTION
## Summary
- add helpers to normalize stage data and detect when a question can advance to the next stage
- build quiz orders by pulling due Stage A–E items first, then Stage F questions, with fallbacks for any remaining slots

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_b_68e201afbf0c8333a1ff12dfc25f2a63