### PR TITLE
Show rank for admin recent answers

### DIFF
--- a/app/static/admin.html
+++ b/app/static/admin.html
@@ -96,7 +96,7 @@
     <section class="card">
       <h3 style="margin:0 0 8px">最近の解答（最大100件）</h3>
       <div style="max-height:340px; overflow:auto">
-        <table id="tbl-recent"><thead><tr><th>日時</th><th>ID</th><th class="center">結果</th><th>ユーザ解答</th><th>正解（英語）</th><th>正解（日本語）</th><th>単元</th><th>ユーザ</th></tr></thead><tbody></tbody></table>
+        <table id="tbl-recent"><thead><tr><th>日時</th><th>ID</th><th class="center">ランク</th><th class="center">結果</th><th>ユーザ解答</th><th>正解（英語）</th><th>正解（日本語）</th><th>単元</th><th>ユーザ</th></tr></thead><tbody></tbody></table>
       </div>
     </section>
 
@@ -233,8 +233,10 @@
         const mark = ok? '○':'×';
         const at = r.at || r.endedAt;
         const dateText = at? new Date(at).toLocaleString(): '―';
+        const rankText = (r && typeof r.rank === 'string') ? r.rank : (r && r.rank ? String(r.rank) : '');
         tr.innerHTML = `<td>${dateText}</td>`+
                        `<td>${r.id||''}</td>`+
+                       `<td class="center">${rankText||''}</td>`+
                        `<td class="center ${ok?'ok':'ng'}">${mark}</td>`+
                        `<td>${r.userAnswer||''}</td>`+
                        `<td>${r.en||''}</td>`+


### PR DESCRIPTION
## Summary
- derive the question rank at the time of each attempt when building the admin summary payload
- surface the per-attempt rank in the recent answers table of the admin dashboard UI

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e22f7f37208333bcc7750695dc7c3e