### PR TITLE
Auto-advance to next question on correct answers (preserve wrong-answer feedback)

### DIFF
--- a/app/static/index.html
+++ b/app/static/index.html
@@ -1522,30 +1522,42 @@
 
       if(correct){
         state.correct++; $('#stat-correct').textContent = state.correct;
-        const detail = buildFeedbackDetail(q, false);
-        $('#explain').innerHTML = `✅ 正解！ <span class="muted">${ans}</span>${detail}`;
       } else {
         state.wrong++; $('#stat-wrong').textContent = state.wrong;
-        const detail = buildFeedbackDetail(q, true);
-        const answersMarkup = formatCorrectAnswers(answerList);
-        $('#explain').innerHTML = state.qType==='reorder'
-          ? `❌ 不正解。 正解: ${answersMarkup}${detail}`
-          : `❌ 不正解。 正解: ${answersMarkup}${detail}`;
       }
 
       (state.mode==='review'? state.reviewed : state.answered).push(record);
       noteAttempt(q, correct, record.at, state.mode);
       updateQuestionStat(q, state.order[state.qIndex].bucket);
       state.graded = true;
+
+      if(correct){
+        advanceQuestion();
+        return true;
+      }
+
+      const detail = buildFeedbackDetail(q, true);
+      const answersMarkup = formatCorrectAnswers(answerList);
+      $('#explain').innerHTML = state.qType==='reorder'
+        ? `❌ 不正解。 正解: ${answersMarkup}${detail}`
+        : `❌ 不正解。 正解: ${answersMarkup}${detail}`;
       $('#btn-next').disabled = false;
       updateNextState();
+      return false;
     }
 
-    function nextQuestion(){
-      if(!state.graded) checkAnswer();
+    function advanceQuestion(){
       state.qIndex++;
       if(state.qIndex >= state.order.length){ finishSet(); }
       else { renderQuestion(); }
+    }
+
+    function nextQuestion(){
+      if(!state.graded){
+        const advanced = checkAnswer();
+        if(advanced || !state.graded) return;
+      }
+      advanceQuestion();
     }
 
     function finishSet(){

--- a/app/static/math.html
+++ b/app/static/math.html
@@ -1070,26 +1070,23 @@
       }
       const isCorrect = answers.some(candidate => matchesAnswer(candidate, userValues, fieldSpecs));
       state.graded = true;
-      const btnNext = $('#btn-next');
-      if(btnNext) btnNext.disabled = false;
       const explain = buildExplain(q);
       state.attempt += 1;
       sendMathResult(q, isCorrect, userValues, fieldSpecs);
       if(isCorrect){
-        $('#feedback').className = 'ok';
-        $('#feedback').innerHTML = `✅ 正解です！${explain}`;
-      } else {
-        $('#feedback').className = 'ng';
-        const retryMessage = '❌ 不正解。もう一度チャレンジしてみましょう。';
-        $('#feedback').innerHTML = explain ? `${retryMessage}${explain}` : retryMessage;
+        advanceQuestion();
+        return true;
       }
+
+      const btnNext = $('#btn-next');
+      if(btnNext) btnNext.disabled = false;
+      $('#feedback').className = 'ng';
+      const retryMessage = '❌ 不正解。もう一度チャレンジしてみましょう。';
+      $('#feedback').innerHTML = explain ? `${retryMessage}${explain}` : retryMessage;
+      return false;
     }
 
-    function nextQuestion(){
-      if(!state.graded){
-        checkAnswer();
-        if(!state.graded) return;
-      }
+    function advanceQuestion(){
       const totalQuestions = state.questions.length;
       if(!totalQuestions){
         showSetupView();
@@ -1107,6 +1104,14 @@
       }
       state.index += 1;
       renderQuestion();
+    }
+
+    function nextQuestion(){
+      if(!state.graded){
+        const advanced = checkAnswer();
+        if(advanced || !state.graded) return;
+      }
+      advanceQuestion();
     }
 
     if(startButton){


### PR DESCRIPTION
### Motivation
- ユーザ操作性の改善として、正解時は結果メッセージ表示に長く留まらず即座に次の問題へ移行することを目的としています。
- 不正解時は従来どおり解説や正解表示を行いユーザが内容を確認できるように維持します。

### Description
- `app/static/index.html` の `checkAnswer` ロジックを変更し、正解時はフィードバック表示をスキップして統計更新後に即座に次問へ進むようにしました（正回答は記録・統計更新は行われます）。
- `app/static/math.html` の `checkAnswer` ロジックにも同様の即時遷移を適用しました。
- 問題遷移処理を `advanceQuestion()` に分離して `nextQuestion()` から呼び出す構造にし、手動で「次へ」を押した場合と自動遷移が重複して進行しないようにしました。
- 不正解時はこれまでどおり `buildFeedbackDetail()` / `formatCorrectAnswers()` を使って正解表示と解説を出し、`#btn-next` を有効化する挙動を維持しています.
- 変更対象ファイルは `app/static/index.html` と `app/static/math.html` です。

### Testing
- `pytest` を実行し全テストが通過しました（41 件のテストがすべて成功）。
- `git diff --check` を実行して差分チェックに問題がないことを確認しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a072a28d1308333bdcd4af7410a2b7e)